### PR TITLE
RDKEMW-1766: getDevicePowerState is failing, causing EPG to not start…

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -612,10 +612,24 @@ namespace WPEFramework {
 
         void DisplaySettings::InitializePowerManager()
         {
+            uint32_t count = 0;
             LOGINFO("Connect the COM-RPC socket\n");
-            _powerManagerPlugin = PowerManagerInterfaceBuilder(_T("org.rdk.PowerManager"))
-                .withIShell(m_service)
-                .createInterface();
+            while(count<25){
+                _powerManagerPlugin = PowerManagerInterfaceBuilder(_T("org.rdk.PowerManager"))
+                    .withIShell(m_service)
+                    .createInterface();
+                if (!_powerManagerPlugin)
+                {
+                    count++;
+                    usleep(200*1000);
+                    LOGINFO("retry count: %u",count);
+                }
+                else
+                {
+                    LOGINFO("PowerManager interface get succeed: %u",count);
+                    break;
+                }
+            }
             registerEventHandlers();
         }
 

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -634,10 +634,24 @@ namespace WPEFramework {
 
         void SystemServices::InitializePowerManager()
         {
+            uint32_t count = 0;
             LOGINFO("Connect the COM-RPC socket\n");
-            _powerManagerPlugin = PowerManagerInterfaceBuilder(_T("org.rdk.PowerManager"))
-                .withIShell(m_shellService)
-                .createInterface();
+            while(count<25){
+                _powerManagerPlugin = PowerManagerInterfaceBuilder(_T("org.rdk.PowerManager"))
+                    .withIShell(m_shellService)
+                    .createInterface();
+                if (!_powerManagerPlugin)
+                {
+                    LOGINFO("retry count: %u",count);
+                    count++;
+                    usleep(200*1000);
+                }
+                else
+                {
+                    LOGINFO("PowerManager interface get succeed: %u",count);
+                    break;
+                }
+            }
             registerEventHandlers();
         }
 


### PR DESCRIPTION
RDKEMW-1766: [XIONEUK] getDevicePowerState is failing, causing EPG not to start (Stuck at Sky)

Reason for change: The PowerManager Interface get failed because the client plugin started earlier
Test Procedure: Validate the plugin interface full stack build