### PR TITLE
RDKEMW-2214: Generic way of display info plugin for soc abstraction implementations of displayinfosoc library linking.

### DIFF
--- a/DisplayInfo/CMakeLists.txt
+++ b/DisplayInfo/CMakeLists.txt
@@ -84,6 +84,8 @@ if (USE_DEVICESETTINGS)
             PRIVATE
                 DeviceSettings/RPI/SoC_abstraction.cpp
                 DeviceSettings/RPI/kms.c)
+    elseif (ENABLE_DISPLAYINFO_SOC)
+        target_link_libraries(${MODULE_NAME} PRIVATE displayinfosoc)
     endif()
 
 elseif (NXCLIENT_FOUND AND NEXUS_FOUND)


### PR DESCRIPTION
**Reason for change:** Added the soc abstraction implementations of displayinfosoc library linking.
**Tickets:** RDKEMW-2214 & RDKVREFPLT-4928
**Test Procedure:** Build and verify the displayinfo plugin.
**Risks:** Medium.
**Signed-off-by:** sundaramuneeswaran_muthuraj@comcast.com