### PR TITLE
RDK-57092: PowerManager plugin interface change (minor)

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -4656,7 +4656,7 @@ namespace WPEFramework {
             audioPortInitActive = false;
         }
 
-        void DisplaySettings::onPowerModeChanged(const PowerState &currentState, const PowerState &newState)
+        void DisplaySettings::onPowerModeChanged(const PowerState currentState, const PowerState newState)
         {
             LOGWARN("onPowerModeChanged: State Changed %d --> %d\r",
                          currentState, newState);

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -70,7 +70,7 @@ namespace WPEFramework {
                 ~PowerManagerNotification() override = default;
 
             public:
-                void OnPowerModeChanged(const PowerState &currentState, const PowerState &newState) override
+                void OnPowerModeChanged(const PowerState currentState, const PowerState newState) override
                 {
                     _parent.onPowerModeChanged(currentState, newState);
                 }
@@ -226,7 +226,7 @@ namespace WPEFramework {
             virtual const string Initialize(PluginHost::IShell* service) override;
             virtual void Deinitialize(PluginHost::IShell* service) override;
             virtual string Information() const override { return {}; }
-            void onPowerModeChanged(const PowerState &currentState, const PowerState &newState);
+            void onPowerModeChanged(const PowerState currentState, const PowerState newState);
             void registerEventHandlers();
             BEGIN_INTERFACE_MAP(DisplaySettings)
             INTERFACE_ENTRY(PluginHost::IPlugin)

--- a/PowerManager/PowerManager.h
+++ b/PowerManager/PowerManager.h
@@ -83,31 +83,31 @@ namespace Plugin {
                 _parent.Deactivated(connection);
             }
 
-            void OnPowerModeChanged(const PowerState& currentState, const PowerState& newState) override
+            void OnPowerModeChanged(const PowerState currentState, const PowerState newState) override
             {
                 LOGINFO("currentState %u, newState %u", currentState, newState);
                 Exchange::JPowerManager::Event::OnPowerModeChanged(_parent, currentState, newState);
             }
 
-            void OnPowerModePreChange(const PowerState& currentState, const PowerState& newState, const int trxnId, const int stateChangeAfter) override
+            void OnPowerModePreChange(const PowerState currentState, const PowerState newState, const int trxnId, const int stateChangeAfter) override
             {
                 LOGINFO("currentState %u, newState %u, transactionId %d, stateChangeAfter %d sec", currentState, newState, trxnId, stateChangeAfter);
                 Exchange::JPowerManager::Event::OnPowerModePreChange(_parent, currentState, newState, trxnId, stateChangeAfter);
             }
 
-            void OnDeepSleepTimeout(const int& wakeupTimeout) override
+            void OnDeepSleepTimeout(const int wakeupTimeout) override
             {
                 LOGINFO("wakeupTimeout %d", wakeupTimeout);
                 Exchange::JPowerManager::Event::OnDeepSleepTimeout(_parent, wakeupTimeout);
             }
 
-            void OnNetworkStandbyModeChanged(const bool& enabled) override
+            void OnNetworkStandbyModeChanged(const bool enabled) override
             {
                 LOGINFO("enabled %d", enabled);
                 Exchange::JPowerManager::Event::OnNetworkStandbyModeChanged(_parent, enabled);
             }
 
-            void OnThermalModeChanged(const ThermalTemperature& currentThermalLevel, const ThermalTemperature& newThermalLevel, const float& currentTemperature) override
+            void OnThermalModeChanged(const ThermalTemperature currentThermalLevel, const ThermalTemperature newThermalLevel, const float currentTemperature) override
             {
                 LOGINFO("currentThermalLevel %d, newThermalLevel %d, currentTemperature %f", currentThermalLevel, newThermalLevel, currentTemperature);
                 Exchange::JPowerManager::Event::OnThermalModeChanged(_parent, currentThermalLevel, newThermalLevel, currentTemperature);

--- a/PowerManager/PowerManagerImplementation.cpp
+++ b/PowerManager/PowerManagerImplementation.cpp
@@ -618,7 +618,7 @@ namespace Plugin {
         return errorCode;
     }
 
-    uint32_t PowerManagerImplementation::SetPowerState(const int& keyCode, const PowerState& powerState, const string& standbyReason)
+    uint32_t PowerManagerImplementation::SetPowerState(const int keyCode, const PowerState powerState, const string& standbyReason)
     {
         PowerState currentState = POWER_STATE_UNKNOWN;
         PowerState prevState = POWER_STATE_UNKNOWN;
@@ -889,7 +889,7 @@ namespace Plugin {
         return errorCode;
     }
 
-    uint32_t PowerManagerImplementation::SetNetworkStandbyMode(const bool& standbyMode)
+    uint32_t PowerManagerImplementation::SetNetworkStandbyMode(const bool standbyMode)
     {
         uint32_t errorCode = Core::ERROR_GENERAL;
         IARM_Bus_PWRMgr_NetworkStandbyMode_Param_t param = {};
@@ -939,7 +939,7 @@ namespace Plugin {
         return errorCode;
     }
 
-    uint32_t PowerManagerImplementation::SetWakeupSrcConfig(const int& powerMode, const int& srcType, int config)
+    uint32_t PowerManagerImplementation::SetWakeupSrcConfig(const int powerMode, const int srcType, int config)
     {
         uint32_t errorCode = Core::ERROR_GENERAL;
 
@@ -986,7 +986,7 @@ namespace Plugin {
         return errorCode;
     }
 
-    uint32_t PowerManagerImplementation::SetSystemMode(const SystemMode& currentMode, const SystemMode& newMode) const
+    uint32_t PowerManagerImplementation::SetSystemMode(const SystemMode currentMode, const SystemMode newMode) const
     {
         uint32_t errorCode = Core::ERROR_GENERAL;
         IARM_Bus_CommonAPI_SysModeChange_Param_t modeParam;

--- a/PowerManager/PowerManagerImplementation.h
+++ b/PowerManager/PowerManagerImplementation.h
@@ -186,7 +186,7 @@ namespace Plugin {
         virtual uint32_t Unregister(Exchange::IPowerManager::IThermalModeChangedNotification* notification) override;
 
         uint32_t GetPowerState(PowerState& currentState, PowerState& prevState) const override;
-        uint32_t SetPowerState(const int& keyCode, const PowerState& powerState, const string& standbyReason) override;
+        uint32_t SetPowerState(const int keyCode, const PowerState powerState, const string& standbyReason) override;
         uint32_t GetTemperatureThresholds(float& high, float& critical) const override;
         uint32_t SetTemperatureThresholds(const float high, const float critical) override;
         uint32_t GetOvertempGraceInterval(int& graceInterval) const override;
@@ -196,11 +196,11 @@ namespace Plugin {
         uint32_t GetLastWakeupReason(WakeupReason& wakeupReason) const override;
         uint32_t GetLastWakeupKeyCode(int& keycode) const override;
         uint32_t Reboot(const string& rebootRequestor, const string& rebootReasonCustom, const string& rebootReasonOther) override;
-        uint32_t SetNetworkStandbyMode(const bool& standbyMode) override;
+        uint32_t SetNetworkStandbyMode(const bool standbyMode) override;
         uint32_t GetNetworkStandbyMode(bool& standbyMode) override;
-        uint32_t SetWakeupSrcConfig(const int& powerMode, const int& srcType, int config) override;
+        uint32_t SetWakeupSrcConfig(const int powerMode, const int srcType, int config) override;
         uint32_t GetWakeupSrcConfig(int& powerMode, int& srcType, int& config) const override;
-        uint32_t SetSystemMode(const SystemMode& currentMode, const SystemMode& newMode) const override;
+        uint32_t SetSystemMode(const SystemMode currentMode, const SystemMode newMode) const override;
         uint32_t GetPowerStateBeforeReboot(PowerState& powerStateBeforeReboot) override;
         uint32_t PowerModePreChangeComplete(const uint32_t clientId, const int transactionId) override;
         uint32_t DelayPowerModeChangeBy(const uint32_t clientId, const int transactionId, const int delayPeriod) override;

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -705,7 +705,7 @@ namespace WPEFramework {
             }
         }
 
-        void SystemServices::onPowerModeChanged(const PowerState &currentState, const PowerState &newState)
+        void SystemServices::onPowerModeChanged(const PowerState currentState, const PowerState newState)
         {
             std::string curPowerState,newPowerState = "";
 
@@ -738,7 +738,7 @@ namespace WPEFramework {
         }
 
 
-        void SystemServices::onNetworkStandbyModeChanged(const bool &enabled)
+        void SystemServices::onNetworkStandbyModeChanged(const bool enabled)
         {
             if (SystemServices::_instance) {
                 SystemServices::_instance->onNetworkModeChanged(enabled);
@@ -747,7 +747,7 @@ namespace WPEFramework {
             }
         }
 
-        void SystemServices::onThermalModeChanged(const ThermalTemperature &currentThermalLevel, const ThermalTemperature &newThermalLevel, const float &currentTemperature)
+        void SystemServices::onThermalModeChanged(const ThermalTemperature currentThermalLevel, const ThermalTemperature newThermalLevel, const float currentTemperature)
         {
             handleThermalLevelChange(currentThermalLevel, newThermalLevel, currentTemperature);
         }

--- a/SystemServices/SystemServices.h
+++ b/SystemServices/SystemServices.h
@@ -135,15 +135,15 @@ namespace WPEFramework {
                     ~PowerManagerNotification() override = default;
 
                 public:
-                    void OnPowerModeChanged(const PowerState &currentState, const PowerState &newState) override
+                    void OnPowerModeChanged(const PowerState currentState, const PowerState newState) override
                     {
                         _parent.onPowerModeChanged(currentState, newState);
                     }
-                    void OnNetworkStandbyModeChanged(const bool &enabled) override
+                    void OnNetworkStandbyModeChanged(const bool enabled) override
                     {
                         _parent.onNetworkStandbyModeChanged(enabled);
                     }
-                    void OnThermalModeChanged(const ThermalTemperature &currentThermalLevel, const ThermalTemperature &newThermalLevel, const float &currentTemperature) override
+                    void OnThermalModeChanged(const ThermalTemperature currentThermalLevel, const ThermalTemperature newThermalLevel, const float currentTemperature) override
                     {
                         _parent.onThermalModeChanged(currentThermalLevel, newThermalLevel, currentTemperature);
                     }
@@ -242,10 +242,10 @@ namespace WPEFramework {
                 virtual string Information() const override { return {}; }
                 IPowerManager* getPwrMgrPluginInstance();
                 void registerEventHandlers();
-                void onPowerModeChanged(const PowerState &currentState, const PowerState &newState);
+                void onPowerModeChanged(const PowerState currentState, const PowerState newState);
                 std::string powerModeEnumToString(PowerState state);
-                void onNetworkStandbyModeChanged(const bool &enabled);
-                void onThermalModeChanged(const ThermalTemperature &currentThermalLevel, const ThermalTemperature &newThermalLevel, const float &currentTemperature);
+                void onNetworkStandbyModeChanged(const bool enabled);
+                void onThermalModeChanged(const ThermalTemperature currentThermalLevel, const ThermalTemperature newThermalLevel, const float currentTemperature);
                 void onRebootBegin(const string &rebootReasonCustom, const string &rebootReasonOther, const string &rebootRequestor);
 
                 BEGIN_INTERFACE_MAP(SystemServices)


### PR DESCRIPTION
Reason for change: Interface API arguments not to be passed by reference if it's a primitive data type.
Test Procedure : SetPowerState & QueryPowerState sanity Risks : LOW
Signed-off-by : bp-skamat286 skamath@synamedia.com