### PR TITLE
RDKEMW-4187: Missing error response string in the isClean method

### DIFF
--- a/Warehouse/WarehouseImplementation.cpp
+++ b/Warehouse/WarehouseImplementation.cpp
@@ -431,9 +431,8 @@ namespace WPEFramework
             
             if (listPathsToRemove.size() == 0)
             {
-                std::string msg = "file " CUSTOM_DATA_FILE " doesn't have any lines with paths";
-                LOGERR("%s", msg.c_str());
-                error = msg;
+                LOGERR("file %s doesn't have any lines with paths", CUSTOM_DATA_FILE );
+                error = "file " CUSTOM_DATA_FILE " doesn't have any lines with paths";
                 success = false;
                 clean = false;
                 list.push_back("");
@@ -726,7 +725,7 @@ namespace WPEFramework
             Core::IWorkerPool::Instance().Submit(Job::Create(this, event, params));
         }
 
-        void WarehouseImplementation::Dispatch(Event event, const JsonObject params)
+        void WarehouseImplementation::Dispatch(Event event, const JsonObject &params)
         {
             _adminLock.Lock();
         

--- a/Warehouse/WarehouseImplementation.cpp
+++ b/Warehouse/WarehouseImplementation.cpp
@@ -721,12 +721,12 @@ namespace WPEFramework
             return Core::ERROR_NONE;
         }
 
-        void WarehouseImplementation::dispatchEvent(Event event, const JsonValue &params)
+        void WarehouseImplementation::dispatchEvent(Event event, const JsonObject &params)
         {
             Core::IWorkerPool::Instance().Submit(Job::Create(this, event, params));
         }
 
-        void WarehouseImplementation::Dispatch(Event event, const JsonValue params)
+        void WarehouseImplementation::Dispatch(Event event, const JsonObject params)
         {
             _adminLock.Lock();
         
@@ -737,7 +737,9 @@ namespace WPEFramework
                 case WAREHOUSE_EVT_RESET_DONE:
                     while (index != _warehouseNotification.end()) 
                     {
-                        (*index)->ResetDone(params.Boolean(),params.String());
+                        bool success = params["success"].Boolean();
+                        string error = params["error"].String();
+                        (*index)->ResetDone(success,error);
                         ++index;
                     }
                     break;

--- a/Warehouse/WarehouseImplementation.h
+++ b/Warehouse/WarehouseImplementation.h
@@ -102,7 +102,7 @@ namespace WPEFramework
             Core::hresult ExecuteHardwareTest(WarehouseSuccess& success) override;
             Core::hresult GetHardwareTestResults(bool& success, string& testResults) override;
             Core::hresult InternalReset(const string& passPhrase, WarehouseSuccessErr& successErr) override;
-            Core::hresult IsClean(const int age, bool &clean, IStringIterator*& files, bool &success) override;
+            Core::hresult IsClean(const int age, bool &clean, IStringIterator*& files, bool &success, string& error) override;
             Core::hresult LightReset(WarehouseSuccessErr& successErr) override;
             Core::hresult ResetDevice(const bool suppressReboot, const string& resetType, WarehouseSuccessErr& successErr) override;
 

--- a/Warehouse/WarehouseImplementation.h
+++ b/Warehouse/WarehouseImplementation.h
@@ -112,7 +112,7 @@ namespace WPEFramework
             Utils::ThreadRAII m_resetThread;
             
             void dispatchEvent(Event, const JsonObject &params);
-            void Dispatch(Event event, const JsonObject params);
+            void Dispatch(Event event, const JsonObject &params);
             static void dsWareHouseOpnStatusChanged(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
             /*gets the SD card mount path by reading /proc/mounts, returns true on success, false otherwise*/
             bool getSDCardMountPath(string&);

--- a/Warehouse/WarehouseImplementation.h
+++ b/Warehouse/WarehouseImplementation.h
@@ -58,7 +58,7 @@ namespace WPEFramework
  
             class EXTERNAL Job : public Core::IDispatch {
             protected:
-                Job(WarehouseImplementation* warehouseImplementation, Event event, JsonValue&  params)
+                Job(WarehouseImplementation* warehouseImplementation, Event event, JsonObject& params)
                     : _warehouseImplementation(warehouseImplementation)
                     , _event(event)
                     , _params(params) {
@@ -78,7 +78,7 @@ namespace WPEFramework
                 }
 
             public:
-                static Core::ProxyType<Core::IDispatch> Create(WarehouseImplementation* warehouseImplementation, Event event, JsonValue  params) {
+                static Core::ProxyType<Core::IDispatch> Create(WarehouseImplementation* warehouseImplementation, Event event, JsonObject params) {
 #ifndef USE_THUNDER_R4
                     return (Core::proxy_cast<Core::IDispatch>(Core::ProxyType<Job>::Create(warehouseImplementation, event, params)));
 #else
@@ -111,8 +111,8 @@ namespace WPEFramework
             std::list<Exchange::IWarehouse::INotification*> _warehouseNotification;
             Utils::ThreadRAII m_resetThread;
             
-            void dispatchEvent(Event, const JsonValue &params);
-            void Dispatch(Event event, const JsonValue params);
+            void dispatchEvent(Event, const JsonObject &params);
+            void Dispatch(Event event, const JsonObject params);
             static void dsWareHouseOpnStatusChanged(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
             /*gets the SD card mount path by reading /proc/mounts, returns true on success, false otherwise*/
             bool getSDCardMountPath(string&);


### PR DESCRIPTION
Reason for change: Added error response string in the isClean method 
Test Procedure: Test isClean method of warehouse plugin
Risks: Medium
Priority: P1
Signed-off-by:Dineshkumar P dinesh_kumar2@comcast.com