### PR TITLE
RDKEMW-3964 DeviceDiagnostics Plugin deactivation fails with 'ERROR_I…

### DIFF
--- a/DeviceDiagnostics/DeviceDiagnosticsImplementation.cpp
+++ b/DeviceDiagnostics/DeviceDiagnosticsImplementation.cpp
@@ -86,6 +86,7 @@ namespace WPEFramework
             m_AVDecoderStatusLock.lock();
             m_pollThreadRun = 0;
             m_AVDecoderStatusLock.unlock();
+            m_avDecoderStatusCv.notify_one();
             m_AVPollThread.join();
             EssRMgrDestroy(m_EssRMgr);
 #endif
@@ -188,16 +189,20 @@ namespace WPEFramework
 #ifdef ENABLE_ERM
         void *DeviceDiagnosticsImplementation::AVPollThread(void *arg)
         {
-            struct timespec poll_wait = { .tv_sec = 30, .tv_nsec = 0  };
             int lastStatus = EssRMgrRes_idle;
             int status;
+            int timeoutInSec = AVDECODERSTATUS_RETRY_INTERVAL;
             DeviceDiagnosticsImplementation* t = DeviceDiagnosticsImplementation::_instance;
 
             LOGINFO("AVPollThread started");
             for (;;)
             {
-                nanosleep(&poll_wait, NULL);
                 std::unique_lock<std::mutex> lock(t->m_AVDecoderStatusLock);
+                if (t->m_avDecoderStatusCv.wait_for(lock, std::chrono::seconds(timeoutInSec)) != std::cv_status::timeout)
+                {
+                    LOGINFO("Received signal. skipping %d sec interval", timeoutInSec);
+                }
+
                 if (t->m_pollThreadRun == 0)
                     break;
 
@@ -222,7 +227,7 @@ namespace WPEFramework
             dispatchEvent(ON_AVDECODER_STATUSCHANGED, params);
         }
 
-        Core::hresult DeviceDiagnosticsImplementation::GetConfiguration(IStringIterator* const& names, Exchange::IDeviceDiagnostics::IDeviceDiagnosticsParamListIterator*& paramList)
+        Core::hresult DeviceDiagnosticsImplementation::GetConfiguration(IStringIterator* const& names, Exchange::IDeviceDiagnostics::IDeviceDiagnosticsParamListIterator*& paramList, bool& success)
         {
 	    LOGINFO("");
 
@@ -246,14 +251,15 @@ namespace WPEFramework
             {
                 paramList = Core::Service<RPC::IteratorType<Exchange::IDeviceDiagnostics::IDeviceDiagnosticsParamListIterator>> \
 				::Create<Exchange::IDeviceDiagnostics::IDeviceDiagnosticsParamListIterator>(deviceDiagnosticsList);
-        
+                success = true;
                 return Core::ERROR_NONE;
             }
 
+            success = false;
             return Core::ERROR_GENERAL;
         }
 
-        Core::hresult DeviceDiagnosticsImplementation::GetMilestones(IStringIterator*& milestones)
+        Core::hresult DeviceDiagnosticsImplementation::GetMilestones(IStringIterator*& milestones, bool& success)
         {
             uint32_t result = Core::ERROR_NONE;
             bool retAPIStatus = false;
@@ -267,35 +273,40 @@ namespace WPEFramework
                 if (!retAPIStatus)
                 {
                     LOGERR("File access failed");
+                    success = false;
                     result = Core::ERROR_GENERAL;
                 }
             }
             else 
             {
                 LOGERR("Expected file not found");
+                success = false;
                 result = Core::ERROR_GENERAL;
             }
 
             if (result == Core::ERROR_NONE)
             {
                 milestones = (Core::Service<RPC::StringIterator>::Create<RPC::IStringIterator>(list));
+                success = true;
             }
 
             return result;
         }
 
-        Core::hresult DeviceDiagnosticsImplementation::LogMilestone(const string& marker)
+        Core::hresult DeviceDiagnosticsImplementation::LogMilestone(const string& marker, bool& success)
         {
 	    LOGINFO("");
             if (marker.empty())
             {
                 LOGERR("Empty marker' parameter");
+                success = false;
                 return Core::ERROR_GENERAL;
             }
 
 #ifdef RDK_LOG_MILESTONE
             logMilestone(marker.c_str());
 #endif
+            success = true;
             return Core::ERROR_NONE; 
 
         }

--- a/DeviceDiagnostics/DeviceDiagnosticsImplementation.h
+++ b/DeviceDiagnostics/DeviceDiagnosticsImplementation.h
@@ -21,8 +21,10 @@
 
 #include <thread>
 #include <mutex>
+#include <condition_variable>
 #ifdef ENABLE_ERM
 #include <essos-resmgr.h>
+#define AVDECODERSTATUS_RETRY_INTERVAL 30 // sec
 #endif
 #ifdef RDK_LOG_MILESTONE
 #include "rdk_logger_milestone.h"
@@ -103,9 +105,9 @@ namespace WPEFramework
             virtual Core::hresult Register(Exchange::IDeviceDiagnostics::INotification *notification ) override ;
             virtual Core::hresult Unregister(Exchange::IDeviceDiagnostics::INotification *notification ) override;
 
-            Core::hresult GetConfiguration(IStringIterator* const& names, Exchange::IDeviceDiagnostics::IDeviceDiagnosticsParamListIterator*& paramList) override;
-            Core::hresult GetMilestones(IStringIterator*& milestones) override;
-            Core::hresult LogMilestone(const string& marker) override;
+            Core::hresult GetConfiguration(IStringIterator* const& names, Exchange::IDeviceDiagnostics::IDeviceDiagnosticsParamListIterator*& paramList, bool& success) override;
+            Core::hresult GetMilestones(IStringIterator*& milestones, bool& success) override;
+            Core::hresult LogMilestone(const string& marker, bool& success) override;
             Core::hresult GetAVDecoderStatus(AvDecoderStatusResult& AVDecoderStatus) override;
 
         private:
@@ -118,6 +120,7 @@ namespace WPEFramework
             std::mutex m_AVDecoderStatusLock;
             EssRMgr* m_EssRMgr;
             int m_pollThreadRun;
+            std::condition_variable m_avDecoderStatusCv;
 #endif
 
             int getMostActiveDecoderStatus();


### PR DESCRIPTION
…NPROGRESS' (#151)

* RDKEMW-3964 DeviceDiagnostics Plugin deactivation fails with 'ERROR_INPROGRESS'

Reason for change: Resolved the DeviceDiagnostics Plugin deactivation fails Test Procedure: Verify the DeviceDiagnostics Plugin deactivation fails Risks: Medium
Priority: P1
Signed-off-by:Dineshkumar P dinesh_kumar2@comcast.com

* RDKEMW-3964 DeviceDiagnostics Plugin deactivation fails with 'ERROR_INPROGRESS'

* RDKEMW-3964: Update DeviceDiagnostics_L2Test.cpp



---------