### PR TITLE
[RDKEMW-2711] RDKEMW-4451 Removing up the unwanted test files from testframework repo

### DIFF
--- a/Tests/L1Tests/CMakeLists.txt
+++ b/Tests/L1Tests/CMakeLists.txt
@@ -117,7 +117,7 @@ endmacro()
 
 # PLUGIN_DEVICEINFO
 #set (DEVICEINFO_INC ${CMAKE_SOURCE_DIR}/../entservices-deviceanddisplay/DeviceInfo ${CMAKE_SOURCE_DIR}/../entservices-deviceanddisplay/helpers)
-#set (DEVICEINFO_SRC tests/test_DeviceInfo.cpp tests/test_DeviceInfoJsonRpc.cpp tests/test_DeviceInfoWeb.cpp tests/test_DeviceVideoCapabilities.cpp)
+#set (DEVICEINFO_SRC tests/test_DeviceAudioCapabilities.cpp tests/test_DeviceInfo.cpp tests/test_DeviceInfoJsonRpc.cpp tests/test_DeviceInfoWeb.cpp test_FirmwareVersion tests/test_DeviceVideoCapabilities.cpp)
 #add_plugin_test_ex(PLUGIN_DEVICEINFO "${DEVICEINFO_SRC}" "${DEVICEINFO_INC}" "${NAMESPACE}DeviceInfo")
 
 # PLUGIN_WAREHOUSE

--- a/Tests/L1Tests/tests/test_DeviceAudioCapabilities.cpp
+++ b/Tests/L1Tests/tests/test_DeviceAudioCapabilities.cpp
@@ -1,0 +1,277 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2024 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#include <gtest/gtest.h>
+
+#include "Implementation/DeviceAudioCapabilities.h"
+
+#include "AudioOutputPortMock.h"
+#include "HostMock.h"
+#include "IarmBusMock.h"
+#include "ManagerMock.h"
+
+#include "exception.hpp"
+#include "ThunderPortability.h"
+
+using namespace WPEFramework;
+
+using ::testing::NiceMock;
+
+class DeviceAudioCapabilitiesTest : public ::testing::Test {
+protected:
+    IarmBusImplMock   *p_iarmBusImplMock = nullptr ;
+    ManagerImplMock   *p_managerImplMock = nullptr ;
+    Core::ProxyType<Plugin::DeviceAudioCapabilities> deviceAudioCapabilities;
+    Exchange::IDeviceAudioCapabilities* interface;
+
+    DeviceAudioCapabilitiesTest()
+    {
+        p_iarmBusImplMock  = new NiceMock <IarmBusImplMock>;
+        IarmBus::setImpl(p_iarmBusImplMock);
+        p_managerImplMock  = new NiceMock <ManagerImplMock>;
+        device::Manager::setImpl(p_managerImplMock);
+
+        EXPECT_CALL(*p_managerImplMock, Initialize())
+            .Times(::testing::AnyNumber())
+            .WillRepeatedly(::testing::Return());
+
+        deviceAudioCapabilities = Core::ProxyType<Plugin::DeviceAudioCapabilities>::Create();
+
+        interface = static_cast<Exchange::IDeviceAudioCapabilities*>(
+        deviceAudioCapabilities->QueryInterface(Exchange::IDeviceAudioCapabilities::ID));
+    }
+
+    virtual ~DeviceAudioCapabilitiesTest()
+    {
+        interface->Release();
+
+        IarmBus::setImpl(nullptr);
+        if (p_iarmBusImplMock != nullptr)
+        {
+            delete p_iarmBusImplMock;
+            p_iarmBusImplMock = nullptr;
+        }
+        device::Manager::setImpl(nullptr);
+        if (p_managerImplMock != nullptr)
+        {
+            delete p_managerImplMock;
+            p_managerImplMock = nullptr;
+        }
+    }
+
+    virtual void SetUp()
+    {
+        ASSERT_TRUE(interface != nullptr);
+    }
+
+    virtual void TearDown()
+    {
+        ASSERT_TRUE(interface != nullptr);
+    }
+};
+
+class DeviceAudioCapabilitiesDsTest : public DeviceAudioCapabilitiesTest {
+protected:
+    HostImplMock      *p_hostImplMock = nullptr ;
+    AudioOutputPortMock      *p_audioOutputPortMock = nullptr ;
+
+    DeviceAudioCapabilitiesDsTest()
+        : DeviceAudioCapabilitiesTest()
+    {
+        p_hostImplMock  = new NiceMock <HostImplMock>;
+        device::Host::setImpl(p_hostImplMock);
+        p_audioOutputPortMock  = new NiceMock <AudioOutputPortMock>;
+        device::AudioOutputPort::setImpl(p_audioOutputPortMock);
+    }
+    virtual ~DeviceAudioCapabilitiesDsTest() override
+    {
+        device::AudioOutputPort::setImpl(nullptr);
+        if (p_audioOutputPortMock != nullptr)
+        {
+            delete p_audioOutputPortMock;
+            p_audioOutputPortMock = nullptr;
+        }
+        device::Host::setImpl(nullptr);
+        if (p_hostImplMock != nullptr)
+        {
+            delete p_hostImplMock;
+            p_hostImplMock = nullptr;
+        }
+    }
+};
+
+TEST_F(DeviceAudioCapabilitiesDsTest, SupportedAudioPorts)
+{
+    device::AudioOutputPort audioOutputPort;
+    RPC::IStringIterator* supportedAudioPorts = nullptr;
+    string audioPort(_T("HDMI0"));
+    string element;
+
+    ON_CALL(*p_audioOutputPortMock, getName())
+        .WillByDefault(::testing::ReturnRef(audioPort));
+    ON_CALL(*p_hostImplMock, getAudioOutputPorts())
+        .WillByDefault(::testing::Return(device::List<device::AudioOutputPort>({ audioOutputPort })));
+
+    EXPECT_EQ(Core::ERROR_NONE, interface->SupportedAudioPorts(supportedAudioPorts));
+    ASSERT_TRUE(supportedAudioPorts != nullptr);
+    ASSERT_TRUE(supportedAudioPorts->Next(element));
+    EXPECT_EQ(element, audioPort);
+
+    supportedAudioPorts->Release();
+}
+
+TEST_F(DeviceAudioCapabilitiesDsTest, AudioCapabilities_noParam)
+{
+    device::AudioOutputPort audioOutputPort;
+    Exchange::IDeviceAudioCapabilities::IAudioCapabilityIterator* audioCapabilities = nullptr;
+    string audioPort(_T("HDMI0"));
+    Exchange::IDeviceAudioCapabilities::AudioCapability element;
+
+    ON_CALL(*p_audioOutputPortMock, getAudioCapabilities(::testing::_))
+        .WillByDefault(::testing::Invoke(
+            [&](int* capabilities) {
+                ASSERT_TRUE(capabilities != nullptr);
+                EXPECT_EQ(*capabilities, dsAUDIOSUPPORT_NONE);
+                *capabilities = dsAUDIOSUPPORT_ATMOS | dsAUDIOSUPPORT_DDPLUS;
+            }));
+    ON_CALL(*p_hostImplMock, getDefaultAudioPortName())
+        .WillByDefault(::testing::Return(audioPort));
+    ON_CALL(*p_hostImplMock, getAudioOutputPort(::testing::_))
+        .WillByDefault(::testing::ReturnRef(audioOutputPort));
+
+    EXPECT_EQ(Core::ERROR_NONE, interface->AudioCapabilities(string(), audioCapabilities));
+    ASSERT_TRUE(audioCapabilities != nullptr);
+    ASSERT_TRUE(audioCapabilities->Next(element));
+    EXPECT_EQ(element, Exchange::IDeviceAudioCapabilities::AudioCapability::ATMOS);
+    ASSERT_TRUE(audioCapabilities->Next(element));
+    EXPECT_EQ(element, Exchange::IDeviceAudioCapabilities::AudioCapability::DDPLUS);
+
+    audioCapabilities->Release();
+}
+
+TEST_F(DeviceAudioCapabilitiesDsTest, MS12Capabilities_noParam)
+{
+    device::AudioOutputPort audioOutputPort;
+    Exchange::IDeviceAudioCapabilities::IMS12CapabilityIterator* ms12Capabilities = nullptr;
+    string audioPort(_T("HDMI0"));
+    Exchange::IDeviceAudioCapabilities::MS12Capability element;
+
+    ON_CALL(*p_audioOutputPortMock, getMS12Capabilities(::testing::_))
+        .WillByDefault(::testing::Invoke(
+            [&](int* capabilities) {
+                ASSERT_TRUE(capabilities != nullptr);
+                EXPECT_EQ(*capabilities, dsMS12SUPPORT_NONE);
+                *capabilities = dsMS12SUPPORT_DolbyVolume | dsMS12SUPPORT_InteligentEqualizer;
+            }));
+    ON_CALL(*p_hostImplMock, getDefaultAudioPortName())
+        .WillByDefault(::testing::Return(audioPort));
+    ON_CALL(*p_hostImplMock, getAudioOutputPort(::testing::_))
+        .WillByDefault(::testing::ReturnRef(audioOutputPort));
+
+    EXPECT_EQ(Core::ERROR_NONE, interface->MS12Capabilities(string(), ms12Capabilities));
+    ASSERT_TRUE(ms12Capabilities != nullptr);
+    ASSERT_TRUE(ms12Capabilities->Next(element));
+    EXPECT_EQ(element, Exchange::IDeviceAudioCapabilities::MS12Capability::DOLBYVOLUME);
+    ASSERT_TRUE(ms12Capabilities->Next(element));
+    EXPECT_EQ(element, Exchange::IDeviceAudioCapabilities::MS12Capability::INTELIGENTEQUALIZER);
+
+    ms12Capabilities->Release();
+}
+
+TEST_F(DeviceAudioCapabilitiesDsTest, SupportedMS12AudioProfiles_noParam)
+{
+    device::AudioOutputPort audioOutputPort;
+    RPC::IStringIterator* supportedMS12AudioProfiles = nullptr;
+    string audioPort(_T("HDMI0"));
+    string audioPortMS12AudioProfile(_T("Movie"));
+    string element;
+
+    ON_CALL(*p_audioOutputPortMock, getMS12AudioProfileList())
+        .WillByDefault(::testing::Return(std::vector<std::string>({ audioPortMS12AudioProfile })));
+    ON_CALL(*p_hostImplMock, getDefaultAudioPortName())
+        .WillByDefault(::testing::Return(audioPort));
+    ON_CALL(*p_hostImplMock, getAudioOutputPort(::testing::_))
+        .WillByDefault(::testing::ReturnRef(audioOutputPort));
+
+    EXPECT_EQ(Core::ERROR_NONE, interface->SupportedMS12AudioProfiles(string(), supportedMS12AudioProfiles));
+    ASSERT_TRUE(supportedMS12AudioProfiles != nullptr);
+    ASSERT_TRUE(supportedMS12AudioProfiles->Next(element));
+    EXPECT_EQ(element, audioPortMS12AudioProfile);
+
+    supportedMS12AudioProfiles->Release();
+}
+
+TEST_F(DeviceAudioCapabilitiesDsTest, SupportedAudioPorts_exception)
+{
+    RPC::IStringIterator* supportedAudioPorts = nullptr;
+
+    ON_CALL(*p_hostImplMock, getAudioOutputPorts())
+        .WillByDefault(::testing::Invoke(
+            [&]() -> device::List<device::AudioOutputPort> {
+                throw device::Exception("test");
+            }));
+
+    EXPECT_EQ(Core::ERROR_GENERAL, interface->SupportedAudioPorts(supportedAudioPorts));
+    EXPECT_EQ(supportedAudioPorts, nullptr);
+}
+
+TEST_F(DeviceAudioCapabilitiesDsTest, AudioCapabilities_HDMI0_exception)
+{
+    Exchange::IDeviceAudioCapabilities::IAudioCapabilityIterator* audioCapabilities = nullptr;
+
+    ON_CALL(*p_hostImplMock, getAudioOutputPort(::testing::_))
+        .WillByDefault(::testing::Invoke(
+            [&](const std::string& name) -> device::AudioOutputPort& {
+                EXPECT_EQ(name, _T("HDMI0"));
+                throw device::Exception("test");
+            }));
+
+    EXPECT_EQ(Core::ERROR_GENERAL, interface->AudioCapabilities(string(_T("HDMI0")), audioCapabilities));
+    EXPECT_EQ(audioCapabilities, nullptr);
+}
+
+TEST_F(DeviceAudioCapabilitiesDsTest, MS12Capabilities_HDMI0_exception)
+{
+    Exchange::IDeviceAudioCapabilities::IMS12CapabilityIterator* ms12Capabilities = nullptr;
+
+    ON_CALL(*p_hostImplMock, getAudioOutputPort(::testing::_))
+        .WillByDefault(::testing::Invoke(
+            [&](const std::string& name) -> device::AudioOutputPort& {
+                EXPECT_EQ(name, _T("HDMI0"));
+                throw device::Exception("test");
+            }));
+
+    EXPECT_EQ(Core::ERROR_GENERAL, interface->MS12Capabilities(string(_T("HDMI0")), ms12Capabilities));
+    EXPECT_EQ(ms12Capabilities, nullptr);
+}
+
+TEST_F(DeviceAudioCapabilitiesDsTest, SupportedMS12AudioProfiles_HDMI0_exception)
+{
+    RPC::IStringIterator* supportedMS12AudioProfiles = nullptr;
+
+    ON_CALL(*p_hostImplMock, getAudioOutputPort(::testing::_))
+        .WillByDefault(::testing::Invoke(
+            [&](const std::string& name) -> device::AudioOutputPort& {
+                EXPECT_EQ(name, _T("HDMI0"));
+                throw device::Exception("test");
+            }));
+
+    EXPECT_EQ(Core::ERROR_GENERAL, interface->SupportedMS12AudioProfiles(string(_T("HDMI0")), supportedMS12AudioProfiles));
+    EXPECT_EQ(supportedMS12AudioProfiles, nullptr);
+}

--- a/Tests/L1Tests/tests/test_DeviceVideoCapabilities.cpp
+++ b/Tests/L1Tests/tests/test_DeviceVideoCapabilities.cpp
@@ -1,0 +1,332 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2024 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#include <gtest/gtest.h>
+
+#include "Implementation/DeviceVideoCapabilities.h"
+
+#include "HostMock.h"
+#include "IarmBusMock.h"
+#include "ManagerMock.h"
+#include "VideoOutputPortConfigMock.h"
+#include "VideoOutputPortMock.h"
+#include "VideoOutputPortTypeMock.h"
+#include "VideoResolutionMock.h"
+
+#include "exception.hpp"
+#include "ThunderPortability.h"
+
+using namespace WPEFramework;
+
+using ::testing::NiceMock;
+
+class DeviceVideoCapabilitiesTest : public ::testing::Test {
+protected:
+    IarmBusImplMock   *p_iarmBusImplMock = nullptr ;
+    ManagerImplMock   *p_managerImplMock = nullptr ;
+    Core::ProxyType<Plugin::DeviceVideoCapabilities> deviceVideoCapabilities;
+    Exchange::IDeviceVideoCapabilities* interface;
+
+    DeviceVideoCapabilitiesTest()
+    {
+        p_iarmBusImplMock  = new NiceMock <IarmBusImplMock>;
+        IarmBus::setImpl(p_iarmBusImplMock);
+
+        p_managerImplMock  = new NiceMock <ManagerImplMock>;
+        device::Manager::setImpl(p_managerImplMock);
+
+        EXPECT_CALL(*p_managerImplMock, Initialize())
+            .Times(::testing::AnyNumber())
+            .WillRepeatedly(::testing::Return());
+
+        deviceVideoCapabilities = Core::ProxyType<Plugin::DeviceVideoCapabilities>::Create();
+
+        interface = static_cast<Exchange::IDeviceVideoCapabilities*>(
+            deviceVideoCapabilities->QueryInterface(Exchange::IDeviceVideoCapabilities::ID));
+    }
+    virtual ~DeviceVideoCapabilitiesTest()
+    {
+        interface->Release();
+
+        IarmBus::setImpl(nullptr);
+        if (p_iarmBusImplMock != nullptr)
+        {
+            delete p_iarmBusImplMock;
+            p_iarmBusImplMock = nullptr;
+        }
+        device::Manager::setImpl(nullptr);
+        if (p_managerImplMock != nullptr)
+        {
+            delete p_managerImplMock;
+            p_managerImplMock = nullptr;
+        }
+    }
+
+    virtual void SetUp()
+    {
+        ASSERT_TRUE(interface != nullptr);
+    }
+
+    virtual void TearDown()
+    {
+        ASSERT_TRUE(interface != nullptr);
+    }
+};
+
+class DeviceVideoCapabilitiesDsTest : public DeviceVideoCapabilitiesTest {
+protected:
+        HostImplMock      *p_hostImplMock = nullptr ;
+        VideoOutputPortConfigImplMock      *p_videoOutputPortConfigImplMock = nullptr ;
+        VideoOutputPortTypeMock      *p_videoOutputPortTypeMock = nullptr ;
+        VideoOutputPortMock          *p_videoOutputPortMock = nullptr ;
+        VideoResolutionMock          *p_videoResolutionMock = nullptr ;
+
+    DeviceVideoCapabilitiesDsTest()
+        : DeviceVideoCapabilitiesTest()
+    {
+        p_hostImplMock  = new NiceMock <HostImplMock>;
+        device::Host::setImpl(p_hostImplMock);
+
+        p_videoOutputPortConfigImplMock  = new NiceMock <VideoOutputPortConfigImplMock>;
+        device::VideoOutputPortConfig::setImpl(p_videoOutputPortConfigImplMock);
+
+        p_videoOutputPortTypeMock  = new NiceMock <VideoOutputPortTypeMock>;
+        device::VideoOutputPortType::setImpl(p_videoOutputPortTypeMock);
+
+        p_videoResolutionMock  = new NiceMock <VideoResolutionMock>;
+        device::VideoResolution::setImpl(p_videoResolutionMock);
+
+        p_videoOutputPortMock  = new NiceMock <VideoOutputPortMock>;
+        device::VideoOutputPort::setImpl(p_videoOutputPortMock);
+    }
+    virtual ~DeviceVideoCapabilitiesDsTest() override
+    {
+        device::VideoResolution::setImpl(nullptr);
+        if (p_videoResolutionMock != nullptr)
+        {
+            delete p_videoResolutionMock;
+            p_videoResolutionMock = nullptr;
+        }
+        device::VideoOutputPortType::setImpl(nullptr);
+        if (p_videoOutputPortTypeMock != nullptr)
+        {
+            delete p_videoOutputPortTypeMock;
+            p_videoOutputPortTypeMock = nullptr;
+        }
+        device::VideoOutputPort::setImpl(nullptr);
+        if (p_videoOutputPortMock != nullptr)
+        {
+            delete p_videoOutputPortMock;
+            p_videoOutputPortMock = nullptr;
+        }
+        device::VideoOutputPortConfig::setImpl(nullptr);
+        if (p_videoOutputPortConfigImplMock != nullptr)
+        {
+            delete p_videoOutputPortConfigImplMock;
+            p_videoOutputPortConfigImplMock = nullptr;
+        }
+        device::Host::setImpl(nullptr);
+        if (p_hostImplMock != nullptr)
+        {
+            delete p_hostImplMock;
+            p_hostImplMock = nullptr;
+        }
+    }
+};
+
+TEST_F(DeviceVideoCapabilitiesDsTest, SupportedVideoDisplays)
+{
+    device::VideoOutputPort videoOutputPort;
+    RPC::IStringIterator* supportedVideoDisplays = nullptr;
+    string videoPort(_T("HDMI0"));
+    string element;
+
+    ON_CALL(*p_videoOutputPortMock, getName())
+        .WillByDefault(::testing::ReturnRef(videoPort));
+    ON_CALL(*p_hostImplMock, getVideoOutputPorts())
+        .WillByDefault(::testing::Return(device::List<device::VideoOutputPort>({ videoOutputPort })));
+
+    EXPECT_EQ(Core::ERROR_NONE, interface->SupportedVideoDisplays(supportedVideoDisplays));
+    ASSERT_TRUE(supportedVideoDisplays != nullptr);
+    ASSERT_TRUE(supportedVideoDisplays->Next(element));
+    EXPECT_EQ(element, videoPort);
+
+    supportedVideoDisplays->Release();
+}
+
+TEST_F(DeviceVideoCapabilitiesDsTest, HostEDID)
+{
+    string edid;
+
+    ON_CALL(*p_hostImplMock, getHostEDID(::testing::_))
+        .WillByDefault(::testing::Invoke(
+            [&](std::vector<uint8_t>& edid) {
+                edid = { 't', 'e', 's', 't' };
+            }));
+
+    EXPECT_EQ(Core::ERROR_NONE, interface->HostEDID(edid));
+    EXPECT_EQ(edid, _T("dGVzdA=="));
+}
+
+TEST_F(DeviceVideoCapabilitiesDsTest, DefaultResolution_noParam)
+{
+    NiceMock<VideoOutputPortMock> videoOutputPortMock;
+    device::VideoOutputPort videoOutputPort;
+    device::VideoResolution videoResolution;
+    string videoPort(_T("HDMI0"));
+    string videoPortDefaultResolution(_T("1080p"));
+    string defaultResolution;
+
+    ON_CALL(*p_videoResolutionMock, getName())
+        .WillByDefault(::testing::ReturnRef(videoPortDefaultResolution));
+    ON_CALL(*p_videoOutputPortMock, getDefaultResolution())
+        .WillByDefault(::testing::ReturnRef(videoResolution));
+    ON_CALL(*p_hostImplMock, getDefaultVideoPortName())
+        .WillByDefault(::testing::Return(videoPort));
+    ON_CALL(*p_hostImplMock, getVideoOutputPort(::testing::_))
+        .WillByDefault(::testing::ReturnRef(videoOutputPort));
+
+    EXPECT_EQ(Core::ERROR_NONE, interface->DefaultResolution(string(), defaultResolution));
+    EXPECT_EQ(defaultResolution, videoPortDefaultResolution);
+}
+
+TEST_F(DeviceVideoCapabilitiesDsTest, SupportedResolutions_noParam)
+{
+    NiceMock<VideoOutputPortMock> videoOutputPortMock;
+    device::VideoOutputPort videoOutputPort;
+    device::VideoOutputPortType videoOutputPortType;
+    device::VideoResolution videoResolution;
+    RPC::IStringIterator* supportedResolutions = nullptr;
+    string videoPort(_T("HDMI0"));
+    string videoPortSupportedResolution(_T("1080p"));
+    string element;
+
+    ON_CALL(*p_videoResolutionMock, getName())
+        .WillByDefault(::testing::ReturnRef(videoPortSupportedResolution));
+    ON_CALL(*p_videoOutputPortTypeMock, getSupportedResolutions())
+        .WillByDefault(::testing::Return(device::List<device::VideoResolution>({ videoResolution })));
+    ON_CALL(*p_videoOutputPortTypeMock, getId())
+        .WillByDefault(::testing::Return(0));
+    ON_CALL(*p_videoOutputPortMock, getType())
+        .WillByDefault(::testing::ReturnRef(videoOutputPortType));
+    ON_CALL(*p_hostImplMock, getDefaultVideoPortName())
+        .WillByDefault(::testing::Return(videoPort));
+    ON_CALL(*p_hostImplMock, getVideoOutputPort(::testing::_))
+        .WillByDefault(::testing::ReturnRef(videoOutputPort));
+    ON_CALL(*p_videoOutputPortConfigImplMock, getPortType(::testing::_))
+        .WillByDefault(::testing::ReturnRef(videoOutputPortType));
+
+    EXPECT_EQ(Core::ERROR_NONE, interface->SupportedResolutions(string(), supportedResolutions));
+    ASSERT_TRUE(supportedResolutions != nullptr);
+    ASSERT_TRUE(supportedResolutions->Next(element));
+    EXPECT_EQ(element, videoPortSupportedResolution);
+
+    supportedResolutions->Release();
+}
+
+TEST_F(DeviceVideoCapabilitiesDsTest, SupportedHdcp_noParam)
+{
+    NiceMock<VideoOutputPortMock> videoOutputPortMock;
+    device::VideoOutputPort videoOutputPort;
+    string videoPort(_T("HDMI0"));
+    auto supportedHDCPVersion = Exchange::IDeviceVideoCapabilities::CopyProtection::HDCP_UNAVAILABLE;
+
+    ON_CALL(*p_videoOutputPortMock, getHDCPProtocol())
+        .WillByDefault(::testing::Return(dsHDCP_VERSION_2X));
+    ON_CALL(*p_hostImplMock, getDefaultVideoPortName())
+        .WillByDefault(::testing::Return(videoPort));
+    ON_CALL(*p_videoOutputPortConfigImplMock, getPort(::testing::_))
+        .WillByDefault(::testing::ReturnRef(videoOutputPort));
+
+    EXPECT_EQ(Core::ERROR_NONE, interface->SupportedHdcp(string(), supportedHDCPVersion));
+    EXPECT_EQ(supportedHDCPVersion, Exchange::IDeviceVideoCapabilities::CopyProtection::HDCP_22);
+}
+
+TEST_F(DeviceVideoCapabilitiesDsTest, SupportedVideoDisplays_exception)
+{
+    RPC::IStringIterator* supportedVideoDisplays = nullptr;
+
+    ON_CALL(*p_hostImplMock, getVideoOutputPorts())
+        .WillByDefault(::testing::Invoke(
+            [&]() -> device::List<device::VideoOutputPort> {
+                throw device::Exception("test");
+            }));
+
+    EXPECT_EQ(Core::ERROR_GENERAL, interface->SupportedVideoDisplays(supportedVideoDisplays));
+    EXPECT_EQ(supportedVideoDisplays, nullptr);
+}
+
+TEST_F(DeviceVideoCapabilitiesDsTest, HostEDID_exception)
+{
+    string edid;
+
+    ON_CALL(*p_hostImplMock, getHostEDID(::testing::_))
+        .WillByDefault(::testing::Invoke(
+            [&](std::vector<uint8_t>& edid) {
+                throw device::Exception("test");
+            }));
+
+    EXPECT_EQ(Core::ERROR_GENERAL, interface->HostEDID(edid));
+    EXPECT_EQ(edid, string());
+}
+
+TEST_F(DeviceVideoCapabilitiesDsTest, DefaultResolution_HDMI0_exception)
+{
+    string defaultResolution;
+
+    ON_CALL(*p_hostImplMock, getVideoOutputPort(::testing::_))
+        .WillByDefault(::testing::Invoke(
+            [&](const std::string& name) -> device::VideoOutputPort& {
+                EXPECT_EQ(name, _T("HDMI0"));
+                throw device::Exception("test");
+            }));
+
+    EXPECT_EQ(Core::ERROR_GENERAL, interface->DefaultResolution(string(_T("HDMI0")), defaultResolution));
+    EXPECT_EQ(defaultResolution, string());
+}
+
+TEST_F(DeviceVideoCapabilitiesDsTest, SupportedResolutions_HDMI0_exception)
+{
+    RPC::IStringIterator* supportedResolutions = nullptr;
+
+    ON_CALL(*p_hostImplMock, getVideoOutputPort(::testing::_))
+        .WillByDefault(::testing::Invoke(
+            [&](const std::string& name) -> device::VideoOutputPort& {
+                EXPECT_EQ(name, _T("HDMI0"));
+                throw device::Exception("test");
+            }));
+
+    EXPECT_EQ(Core::ERROR_GENERAL, interface->SupportedResolutions(string(_T("HDMI0")), supportedResolutions));
+    EXPECT_EQ(supportedResolutions, nullptr);
+}
+
+TEST_F(DeviceVideoCapabilitiesDsTest, SupportedHdcp_HDMI0_exception)
+{
+    auto supportedHDCPVersion = Exchange::IDeviceVideoCapabilities::CopyProtection::HDCP_UNAVAILABLE;
+
+    ON_CALL(*p_videoOutputPortConfigImplMock, getPort(::testing::_))
+        .WillByDefault(::testing::Invoke(
+            [&](const std::string& name) -> device::VideoOutputPort& {
+                EXPECT_EQ(name, _T("HDMI0"));
+                throw device::Exception("test");
+            }));
+
+    EXPECT_EQ(Core::ERROR_GENERAL, interface->SupportedHdcp(string(_T("HDMI0")), supportedHDCPVersion));
+    EXPECT_EQ(supportedHDCPVersion, Exchange::IDeviceVideoCapabilities::CopyProtection::HDCP_UNAVAILABLE);
+}

--- a/Tests/L1Tests/tests/test_FirmwareVersion.cpp
+++ b/Tests/L1Tests/tests/test_FirmwareVersion.cpp
@@ -1,0 +1,98 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2024 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#include <gtest/gtest.h>
+
+#include "Implementation/FirmwareVersion.h"
+
+#include <fstream>
+#include "ThunderPortability.h"
+
+using namespace WPEFramework;
+
+class FirmwareVersionTest : public ::testing::Test {
+protected:
+    Core::ProxyType<Plugin::FirmwareVersion> firmwareVersion;
+    Exchange::IFirmwareVersion* interface;
+
+    FirmwareVersionTest()
+        : firmwareVersion(Core::ProxyType<Plugin::FirmwareVersion>::Create())
+    {
+        interface = static_cast<Exchange::IFirmwareVersion*>(
+            firmwareVersion->QueryInterface(Exchange::IFirmwareVersion::ID));
+    }
+    virtual ~FirmwareVersionTest()
+    {
+        interface->Release();
+    }
+
+    virtual void SetUp()
+    {
+        ASSERT_TRUE(interface != nullptr);
+    }
+
+    virtual void TearDown()
+    {
+        ASSERT_TRUE(interface != nullptr);
+    }
+};
+
+TEST_F(FirmwareVersionTest, Imagename)
+{
+    std::ofstream file("/version.txt");
+    file << "imagename:CUSTOM5_VBN_2203_sprint_20220331225312sdy_NG";
+    file.close();
+
+    string imagename;
+    EXPECT_EQ(Core::ERROR_NONE, interface->Imagename(imagename));
+    EXPECT_EQ(imagename, _T("CUSTOM5_VBN_2203_sprint_20220331225312sdy_NG"));
+}
+
+TEST_F(FirmwareVersionTest, Sdk)
+{
+    std::ofstream file("/version.txt");
+    file << "SDK_VERSION=17.3";
+    file.close();
+
+    string sdk;
+    EXPECT_EQ(Core::ERROR_NONE, interface->Sdk(sdk));
+    EXPECT_EQ(sdk, _T("17.3"));
+}
+
+TEST_F(FirmwareVersionTest, Mediarite)
+{
+    std::ofstream file("/version.txt");
+    file << "MEDIARITE=8.3.53";
+    file.close();
+
+    string mediarite;
+    EXPECT_EQ(Core::ERROR_NONE, interface->Mediarite(mediarite));
+    EXPECT_EQ(mediarite, _T("8.3.53"));
+}
+
+TEST_F(FirmwareVersionTest, Yocto)
+{
+    std::ofstream file("/version.txt");
+    file << "YOCTO_VERSION=dunfell";
+    file.close();
+
+    string yocto;
+    EXPECT_EQ(Core::ERROR_NONE, interface->Yocto(yocto));
+    EXPECT_EQ(yocto, _T("dunfell"));
+}


### PR DESCRIPTION
Reason for change: Adding all deviceinfo related testfiles
Test Procedure: NA
Risks: None
Priority: P2
Signed-off-by: bp-ppriya193@cable.comcast.com