### PR TITLE
RDKEMW-2653 ISystemMode.h Interface header not following coding guide…

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -6074,7 +6074,7 @@ void DisplaySettings::sendMsgThread()
 
 	    return mode;
         }
-   void DisplaySettings::Request(const string& newState)
+    Core::hresult DisplaySettings::Request(const string& newState)
 	{
 		vector<string> connectedDisplays;
 		getConnectedVideoDisplaysHelper(connectedDisplays);
@@ -6102,7 +6102,9 @@ void DisplaySettings::sendMsgThread()
 		if( 0 == (int)connectedDisplays.size())
 		{
 			LOGWARN("No display connected to device (or)device's powerstate is not ON");
+            return Core::ERROR_GENERAL;
 		}
+        return Core::ERROR_NONE;
 	}
     } // namespace Plugin
 } // namespace WPEFramework

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -234,7 +234,7 @@ namespace WPEFramework {
 	    INTERFACE_ENTRY(Exchange::IDeviceOptimizeStateActivator)
             END_INTERFACE_MAP
 
-	    void Request(const string& newState);
+	    Core::hresult Request(const string& newState);
 
         private:
             void InitializeIARM();

--- a/SystemMode/SystemModeImplementation.cpp
+++ b/SystemMode/SystemModeImplementation.cpp
@@ -249,7 +249,7 @@ Core::hresult SystemModeImplementation::GetState(const SystemMode pSystemMode, G
 
 }
 
-uint32_t SystemModeImplementation::ClientActivated(const string& callsign , const string& systemMode)
+Core::hresult SystemModeImplementation::ClientActivated(const string& callsign , const string& systemMode)
 {
 	SystemMode pSystemMode ;
 	auto it = SystemModeInterfaceMap.find(systemMode);
@@ -326,7 +326,7 @@ uint32_t SystemModeImplementation::ClientActivated(const string& callsign , cons
 	}
 	return 0;	
 }
-uint32_t SystemModeImplementation::ClientDeactivated(const string& callsign ,const string& systemMode)
+Core::hresult SystemModeImplementation::ClientDeactivated(const string& callsign ,const string& systemMode)
 {
 	SystemMode pSystemMode ;
 

--- a/SystemMode/SystemModeImplementation.h
+++ b/SystemMode/SystemModeImplementation.h
@@ -57,8 +57,8 @@ namespace Plugin {
 	Core::hresult RequestState(const SystemMode systemMode, const State state ) override;
 	Core::hresult GetState(const SystemMode systemMode , GetStateResult& successResult)const override;
 	
-	virtual uint32_t ClientActivated(const string& callsign ,const string& systemMode) override ;
-	virtual uint32_t ClientDeactivated(const string& callsign, const string& systemMode) override ;
+	virtual Core::hresult ClientActivated(const string& callsign ,const string& systemMode) override ;
+	virtual Core::hresult ClientDeactivated(const string& callsign, const string& systemMode) override ;
 
     private:
         mutable Core::CriticalSection _adminLock;


### PR DESCRIPTION
…line

Reason for change: Solve the guideline issues on ISystemMode.h
Test Procedure: verify build success and basic test
Risks: Low
Priority: P1
Signed-off-by: ramkumar_prabaharan@comcast.com