### PR TITLE
RDKEMW-2653 ISystemMode.h Interface header not following coding guideline

### DIFF
--- a/.github/workflows/L2-tests.yml
+++ b/.github/workflows/L2-tests.yml
@@ -142,7 +142,7 @@ jobs:
         with:
           repository: rdkcentral/entservices-apis
           path: entservices-apis
-          ref: ${{env.INTERFACES_REF}}
+          ref: RDKEMW-2653_ISystemMode_V1
           run: rm -rf $GITHUB_WORKSPACE/entservices-apis/jsonrpc/DTV.json
 
       - name: Apply patches entservices-apis
@@ -344,7 +344,7 @@ jobs:
           -DCMAKE_DISABLE_FIND_PACKAGE_RBus=ON
           -DPLUGIN_SYSTEMSERVICES=ON
           -DPLUGIN_POWERMANAGER=ON
-          -DPLUGIN_DEVICEDIAGNOSTICS=ON
+          -DPLUGIN_DEVICEDIAGNOSTICS=OFF
           -DPLUGIN_DISPLAYSETTINGS=ON
           -DPLUGIN_WAREHOUSE=OFF
           -DUSE_THUNDER_R4=ON
@@ -423,7 +423,7 @@ jobs:
           -DPLUGIN_SYSTEMSERVICES=OFF
           -DPLUGIN_POWERMANAGER=ON
           -DPLUGIN_DISPLAYSETTINGS=ON
-          -DPLUGIN_DEVICEDIAGNOSTICS=ON
+          -DPLUGIN_DEVICEDIAGNOSTICS=OFF
           -DPLUGIN_WAREHOUSE=OFF
           -DPLUGIN_AVINPUT=OFF
           -DPLUGIN_AVOUTPUT=OFF

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -6074,7 +6074,7 @@ void DisplaySettings::sendMsgThread()
 
 	    return mode;
         }
-   void DisplaySettings::Request(const string& newState)
+    Core::hresult DisplaySettings::Request(const string& newState)
 	{
 		vector<string> connectedDisplays;
 		getConnectedVideoDisplaysHelper(connectedDisplays);
@@ -6102,7 +6102,9 @@ void DisplaySettings::sendMsgThread()
 		if( 0 == (int)connectedDisplays.size())
 		{
 			LOGWARN("No display connected to device (or)device's powerstate is not ON");
+            return Core::ERROR_GENERAL;
 		}
+        return Core::ERROR_NONE;
 	}
     } // namespace Plugin
 } // namespace WPEFramework

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -234,7 +234,7 @@ namespace WPEFramework {
 	    INTERFACE_ENTRY(Exchange::IDeviceOptimizeStateActivator)
             END_INTERFACE_MAP
 
-	    void Request(const string& newState);
+	    Core::hresult Request(const string& newState);
 
         private:
             void InitializeIARM();

--- a/SystemMode/SystemModeImplementation.cpp
+++ b/SystemMode/SystemModeImplementation.cpp
@@ -249,7 +249,7 @@ Core::hresult SystemModeImplementation::GetState(const SystemMode pSystemMode, G
 
 }
 
-uint32_t SystemModeImplementation::ClientActivated(const string& callsign , const string& systemMode)
+Core::hresult SystemModeImplementation::ClientActivated(const string& callsign , const string& systemMode)
 {
 	SystemMode pSystemMode ;
 	auto it = SystemModeInterfaceMap.find(systemMode);
@@ -326,7 +326,7 @@ uint32_t SystemModeImplementation::ClientActivated(const string& callsign , cons
 	}
 	return 0;	
 }
-uint32_t SystemModeImplementation::ClientDeactivated(const string& callsign ,const string& systemMode)
+Core::hresult SystemModeImplementation::ClientDeactivated(const string& callsign ,const string& systemMode)
 {
 	SystemMode pSystemMode ;
 

--- a/SystemMode/SystemModeImplementation.h
+++ b/SystemMode/SystemModeImplementation.h
@@ -57,8 +57,8 @@ namespace Plugin {
 	Core::hresult RequestState(const SystemMode systemMode, const State state ) override;
 	Core::hresult GetState(const SystemMode systemMode , GetStateResult& successResult)const override;
 	
-	virtual uint32_t ClientActivated(const string& callsign ,const string& systemMode) override ;
-	virtual uint32_t ClientDeactivated(const string& callsign, const string& systemMode) override ;
+	virtual Core::hresult ClientActivated(const string& callsign ,const string& systemMode) override ;
+	virtual Core::hresult ClientDeactivated(const string& callsign, const string& systemMode) override ;
 
     private:
         mutable Core::CriticalSection _adminLock;


### PR DESCRIPTION
Reason for change: L2 testing
Test Procedure: verify build success and basic test
Risks: Low
Priority: P1
Signed-off-by: ramkumar_prabaharan@comcast.com