### PR TITLE
RDKTV-36733: Fix intermittent 20s delay in DEEPSLEEP to ON transition

### DIFF
--- a/PowerManager/PowerManagerImplementation.h
+++ b/PowerManager/PowerManagerImplementation.h
@@ -222,7 +222,10 @@ namespace Plugin {
         bool m_networkStandbyModeValid;
         bool m_powerStateBeforeRebootValid;
 
-        mutable Core::CriticalSection _adminLock;
+        // lock to guard all apis of PowerManager
+        mutable Core::CriticalSection _apiLock;
+        // lock to guard all notification from PowerManager to clients and also their callback register & unregister
+        mutable Core::CriticalSection _callbackLock;
         Core::ProxyType<RPC::InvokeServerType<1, 0, 4>> _engine;
         Core::ProxyType<RPC::CommunicatorClient> _communicatorClient;
         PluginHost::IShell* _controller;


### PR DESCRIPTION
Reason for change: During the DEEPSLEEP wake-up sequence, SetPowerState was being invoked while client notifications for the DEEPSLEEP to LIGHTSLEEP transition were still in progress. A shared lock between the notification callbacks and SetPowerState caused the latter to be blocked until all notifications completed, resulting in a 20-second delay.

To resolve this, separate locks are now used for notification callbacks and API handling to avoid contention.

Test Procedure: basic PowerState change sanity, verify DEEPSLEEP wakeup.

Risk: Low