### PR TITLE
[RDKEMW-2711] RDKEMW-4650: Enabling the L1/L2 test in the Testframewo…

### DIFF
--- a/.github/workflows/L1-tests.yml
+++ b/.github/workflows/L1-tests.yml
@@ -121,6 +121,14 @@ jobs:
         with:
           path: entservices-deviceanddisplay
 
+      - name: Checkout googletest
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/checkout@v3
+        with:
+          repository: google/googletest
+          path: googletest
+          ref: v1.15.0
+
       - name: Apply patches ThunderTools
         run: |  
           cd $GITHUB_WORKSPACE/ThunderTools
@@ -337,6 +345,22 @@ jobs:
           &&
           cmake --install build/mocks
 
+      - name: Build googletest
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: >
+          cmake -G Ninja
+          -S "$GITHUB_WORKSPACE/googletest"
+          -B build/googletest
+          -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/install/usr"
+          -DCMAKE_MODULE_PATH="$GITHUB_WORKSPACE/install/tools/cmake"
+          -DGENERIC_CMAKE_MODULE_PATH="$GITHUB_WORKSPACE/install/tools/cmake"
+          -DBUILD_TYPE=Debug
+          -DBUILD_GMOCK=ON
+          &&
+          cmake --build build/googletest -j8
+          &&
+          cmake --install build/googletest
+
       - name: Build entservices-deviceanddisplay
         run: >
           cmake -G Ninja
@@ -363,6 +387,8 @@ jobs:
           -I $GITHUB_WORKSPACE/entservices-testframework/Tests
           -I $GITHUB_WORKSPACE/Thunder/Source
           -I $GITHUB_WORKSPACE/Thunder/Source/core
+          -I $GITHUB_WORKSPACE/install/usr/include
+          -I $GITHUB_WORKSPACE/install/usr/include/WPEFramework
           -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/devicesettings.h
           -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/Iarm.h
           -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/Rfc.h
@@ -442,6 +468,8 @@ jobs:
           -I $GITHUB_WORKSPACE/entservices-testframework/Tests
           -I $GITHUB_WORKSPACE/Thunder/Source
           -I $GITHUB_WORKSPACE/Thunder/Source/core
+          -I $GITHUB_WORKSPACE/install/usr/include
+          -I $GITHUB_WORKSPACE/install/usr/include/WPEFramework
           -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/devicesettings.h
           -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/Iarm.h
           -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/Rfc.h
@@ -457,7 +485,7 @@ jobs:
           -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/thunder/Communicator.h
           --coverage
           -Wall -Wno-unused-result -Wno-deprecated-declarations -Wno-error=format=
-          -Wl,-wrap,system -Wl,-wrap,popen -Wl,-wrap,syslog
+          -Wl,-wrap,system -Wl,-wrap,popen -Wl,-wrap,syslog -Wl,--no-as-needed
           -DENABLE_TELEMETRY_LOGGING
           -DUSE_IARMBUS
           -DENABLE_SYSTEM_GET_STORE_DEMO_LINK
@@ -478,6 +506,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=Debug
           -DDS_FOUND=ON
           -DHAS_FRONT_PANEL=ON
+          -DPLUGIN_SYSTEMSERVICES=ON
           -DPLUGIN_POWERMANAGER=ON
           -DPLUGIN_FRAMERATE=ON
           -DPLUGIN_USERPREFERENCES=ON

--- a/.github/workflows/L2-tests.yml
+++ b/.github/workflows/L2-tests.yml
@@ -91,6 +91,14 @@ jobs:
           ref: develop
           token: ${{ secrets.RDKCM_RDKE }}
 
+      - name: Checkout googletest
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/checkout@v3
+        with:
+          repository: google/googletest
+          path: googletest
+          ref: v1.15.0
+
       - name: Apply patches ThunderTools
         run: |  
           cd $GITHUB_WORKSPACE/ThunderTools
@@ -259,6 +267,22 @@ jobs:
           &&
           cmake --install build/mocks
 
+      - name: Build googletest
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: >
+          cmake -G Ninja
+          -S "$GITHUB_WORKSPACE/googletest"
+          -B build/googletest
+          -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/install/usr"
+          -DCMAKE_MODULE_PATH="$GITHUB_WORKSPACE/install/tools/cmake"
+          -DGENERIC_CMAKE_MODULE_PATH="$GITHUB_WORKSPACE/install/tools/cmake"
+          -DBUILD_TYPE=Debug
+          -DBUILD_GMOCK=ON
+          &&
+          cmake --build build/googletest -j8
+          &&
+          cmake --install build/googletest
+
       - name: Build entservices-deviceanddisplay
         run: >
           cmake
@@ -286,6 +310,7 @@ jobs:
           -I $GITHUB_WORKSPACE/entservices-testframework/Tests/headers/systemservices
           -I $GITHUB_WORKSPACE/entservices-testframework/Tests/headers/systemservices/proc
           -I $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks
+          -I $GITHUB_WORKSPACE/install/usr/include
           -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/devicesettings.h
           -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/Iarm.h
           -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/Rfc.h
@@ -385,6 +410,7 @@ jobs:
           -I $GITHUB_WORKSPACE/entservices-testframework/Tests/headers/systemservices
           -I $GITHUB_WORKSPACE/entservices-testframework/Tests/headers/systemservices/proc
           -I $GITHUB_WORKSPACE/entservices-deviceanddisplay/helpers
+          -I $GITHUB_WORKSPACE/install/usr/include
           -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/devicesettings.h
           -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/Iarm.h
           -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/Rfc.h
@@ -406,6 +432,7 @@ jobs:
           -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/essos-resmgr.h
           -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/rdk_logger_milestone.h
           -Werror -Wall -Wno-unused-result -Wno-deprecated-declarations -Wno-error=format=
+          -Wl,--no-as-needed
           -DUSE_IARMBUS
           -DENABLE_ERM
           -DRDK_LOG_MILESTONE
@@ -421,7 +448,7 @@ jobs:
           -DCMAKE_DISABLE_FIND_PACKAGE_Udev=ON
           -DCMAKE_DISABLE_FIND_PACKAGE_RFC=ON
           -DCMAKE_DISABLE_FIND_PACKAGE_RBus=ON
-          -DPLUGIN_SYSTEMSERVICES=OFF
+          -DPLUGIN_SYSTEMSERVICES=ON
           -DPLUGIN_POWERMANAGER=ON
           -DPLUGIN_DISPLAYSETTINGS=ON
           -DPLUGIN_DEVICEDIAGNOSTICS=ON

--- a/Tests/L1Tests/CMakeLists.txt
+++ b/Tests/L1Tests/CMakeLists.txt
@@ -20,24 +20,16 @@ cmake_minimum_required(VERSION 3.8)
 set(PLUGIN_NAME L1TestsDD)
 set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(${NAMESPACE}Plugins REQUIRED)
-
-include(FetchContent)
-FetchContent_Declare(
-        googletest
-        URL https://github.com/google/googletest/archive/e39786088138f2749d64e9e90e0f9902daa77c40.zip
-)
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-FetchContent_MakeAvailable(googletest)
 
 set (TEST_SRC
     tests/test_UtilsFile.cpp
 )
 
 set (TEST_LIB
-    gmock_main
     ${NAMESPACE}Plugins::${NAMESPACE}Plugins
 )
 
@@ -144,6 +136,13 @@ add_plugin_test_ex(PLUGIN_DEVICEDIAGNOSTICS tests/test_DeviceDiagnostics.cpp "${
 
 add_library(${MODULE_NAME} SHARED ${TEST_SRC})
 
+set_source_files_properties(
+        tests/test_DeviceAudioCapabilities.cpp
+        tests/test_DeviceVideoCapabilities.cpp
+        tests/test_SystemServices.cpp
+        tests/test_Warehouse.cpp
+        PROPERTIES COMPILE_FLAGS "-fexceptions")
+
 if (RDK_SERVICES_L1_TEST)
    find_library(TESTMOCKLIB_LIBRARIES NAMES L1TestMocklib)
    if (TESTMOCKLIB_LIBRARIES)
@@ -156,7 +155,7 @@ endif (RDK_SERVICES_L1_TEST)
 
 include_directories(${TEST_INC})
 
-target_link_directories(${MODULE_NAME} PUBLIC ${CMAKE_INSTALL_PREFIX}/lib/wpeframework/plugins)
+target_link_directories(${MODULE_NAME} PUBLIC ${CMAKE_INSTALL_PREFIX}/lib ${CMAKE_INSTALL_PREFIX}/lib/wpeframework/plugins)
 
 target_link_libraries(${MODULE_NAME} ${TEST_LIB})
 

--- a/Tests/L1Tests/tests/test_SystemServices.cpp
+++ b/Tests/L1Tests/tests/test_SystemServices.cpp
@@ -38,6 +38,7 @@
 #include "ThunderPortability.h"
 
 using namespace WPEFramework;
+using ::testing::Matcher;
 
 class SystemServicesTest : public ::testing::Test {
 protected:
@@ -53,7 +54,7 @@ protected:
     SleepModeMock* p_sleepModeMock = nullptr;
     HostImplMock* p_hostImplMock = nullptr;
     readprocImplMock* p_readprocImplMock = nullptr;
-    Exchange::IPowerManager::INetworkStandbyModeChangedNotification* _networkStandbyModeChangedNotification = nullptr,
+    Exchange::IPowerManager::INetworkStandbyModeChangedNotification* _networkStandbyModeChangedNotification = nullptr;
     Exchange::IPowerManager::IThermalModeChangedNotification* _thermalModeChangedNotification = nullptr;
     Exchange::IPowerManager::IRebootNotification* _rebootNotification = nullptr;
     Exchange::IPowerManager::IModeChangedNotification* _modeChangedNotification = nullptr;
@@ -86,28 +87,28 @@ protected:
         p_readprocImplMock = new NiceMock<readprocImplMock>;
         ProcImpl::setImpl(p_readprocImplMock);
 
-        EXPECT_CALL(PowerManagerMock::Mock(), Register(::testing::_))
+        EXPECT_CALL(PowerManagerMock::Mock(), Register(::testing::Matcher<Exchange::IPowerManager::INetworkStandbyModeChangedNotification*>(::testing::_)))
             .WillOnce(
                 [this](Exchange::IPowerManager::INetworkStandbyModeChangedNotification* notification) -> uint32_t {
                     _networkStandbyModeChangedNotification = notification;
                     return Core::ERROR_NONE;
                 });
 
-        EXPECT_CALL(PowerManagerMock::Mock(), Register(::testing::_))
+        EXPECT_CALL(PowerManagerMock::Mock(), Register(::testing::Matcher<Exchange::IPowerManager::IRebootNotification*>(::testing::_)))
             .WillOnce(
                 [this](Exchange::IPowerManager::IRebootNotification* notification) -> uint32_t {
                     _rebootNotification = notification;
                     return Core::ERROR_NONE;
                 });
 
-        EXPECT_CALL(PowerManagerMock::Mock(), Register(::testing::_))
+        EXPECT_CALL(PowerManagerMock::Mock(), Register(::testing::Matcher<Exchange::IPowerManager::IThermalModeChangedNotification*>(::testing::_)))
             .WillOnce(
                 [this](Exchange::IPowerManager::IThermalModeChangedNotification* notification) -> uint32_t {
                     _thermalModeChangedNotification = notification;
                     return Core::ERROR_NONE;
                 });
 
-        EXPECT_CALL(PowerManagerMock::Mock(), Register(::testing::_))
+        EXPECT_CALL(PowerManagerMock::Mock(), Register(::testing::Matcher<Exchange::IPowerManager::IModeChangedNotification*>(::testing::_)))
             .WillOnce(
                 [this](Exchange::IPowerManager::IModeChangedNotification* notification) -> uint32_t {
                     _modeChangedNotification = notification;
@@ -1541,7 +1542,7 @@ TEST_F(SystemServicesEventIarmTest, onTemperatureThresholdChangedFailed_withoutV
 
     WPEFramework::Plugin::SystemServices::_instance = nullptr;
 
-    ASSERT_NE(_notification, nullptr);
+    ASSERT_NE(_thermalModeChangedNotification, nullptr);
     _thermalModeChangedNotification->OnThermalModeChanged(IPowerManager::THERMAL_TEMPERATURE_CRITICAL, IPowerManager::THERMAL_TEMPERATURE_HIGH, 0);
 
     EXPECT_EQ(Core::ERROR_TIMEDOUT, onTemperatureThresholdChanged.Lock(100));
@@ -1565,7 +1566,7 @@ TEST_F(SystemServicesEventIarmTest, onTemperatureThresholdChangedFailed_whenNewL
 
     EVENT_SUBSCRIBE(0, _T("onTemperatureThresholdChanged"), _T("org.rdk.System"), message);
 
-    ASSERT_NE(_notification, nullptr);
+    ASSERT_NE(_thermalModeChangedNotification, nullptr);
     _thermalModeChangedNotification->OnThermalModeChanged(IPowerManager::THERMAL_TEMPERATURE_CRITICAL, IPowerManager::THERMAL_TEMPERATURE_UNKNOWN, 0);
 
     EXPECT_EQ(Core::ERROR_TIMEDOUT, onTemperatureThresholdChanged.Lock(100));
@@ -1589,7 +1590,7 @@ TEST_F(SystemServicesEventIarmTest, onTemperatureThresholdChangedFailed_currLeve
 
     EVENT_SUBSCRIBE(0, _T("onTemperatureThresholdChanged"), _T("org.rdk.System"), message);
 
-    ASSERT_NE(_notification, nullptr);
+    ASSERT_NE(_thermalModeChangedNotification, nullptr);
     _thermalModeChangedNotification->OnThermalModeChanged(IPowerManager::THERMAL_TEMPERATURE_UNKNOWN, IPowerManager::THERMAL_TEMPERATURE_NORMAL, 0);
 
     EXPECT_EQ(Core::ERROR_TIMEDOUT, onTemperatureThresholdChanged.Lock(100));
@@ -1613,7 +1614,7 @@ TEST_F(SystemServicesEventIarmTest, onTemperatureThresholdChangedFailed_currLeve
 
     EVENT_SUBSCRIBE(0, _T("onTemperatureThresholdChanged"), _T("org.rdk.System"), message);
 
-    ASSERT_NE(_notification, nullptr);
+    ASSERT_NE(_thermalModeChangedNotification, nullptr);
     _thermalModeChangedNotification->OnThermalModeChanged(IPowerManager::THERMAL_TEMPERATURE_UNKNOWN, IPowerManager::THERMAL_TEMPERATURE_HIGH, 0);
 
     EXPECT_EQ(Core::ERROR_TIMEDOUT, onTemperatureThresholdChanged.Lock(100));
@@ -1637,7 +1638,7 @@ TEST_F(SystemServicesEventIarmTest, onTemperatureThresholdChangedFailed_currLeve
 
     EVENT_SUBSCRIBE(0, _T("onTemperatureThresholdChanged"), _T("org.rdk.System"), message);
 
-    ASSERT_NE(_notification, nullptr);
+    ASSERT_NE(_thermalModeChangedNotification, nullptr);
     _thermalModeChangedNotification->OnThermalModeChanged(IPowerManager::THERMAL_TEMPERATURE_UNKNOWN, IPowerManager::THERMAL_TEMPERATURE_CRITICAL, 0);
 
     EXPECT_EQ(Core::ERROR_TIMEDOUT, onTemperatureThresholdChanged.Lock(100));
@@ -1683,7 +1684,7 @@ TEST_F(SystemServicesEventIarmTest, onTemperatureThresholdChangedSuccess_whenNor
 
     EVENT_SUBSCRIBE(0, _T("onTemperatureThresholdChanged"), _T("org.rdk.System"), message);
 
-    ASSERT_NE(_notification, nullptr);
+    ASSERT_NE(_thermalModeChangedNotification, nullptr);
     _thermalModeChangedNotification->OnThermalModeChanged(IPowerManager::THERMAL_TEMPERATURE_NORMAL, IPowerManager::THERMAL_TEMPERATURE_HIGH, 100.0);
 
     EXPECT_EQ(Core::ERROR_NONE, onTemperatureThresholdChanged.Lock());
@@ -1728,7 +1729,7 @@ TEST_F(SystemServicesEventIarmTest, onTemperatureThresholdChangedSuccess_whenCri
 
     EVENT_SUBSCRIBE(0, _T("onTemperatureThresholdChanged"), _T("org.rdk.System"), message);
 
-    ASSERT_NE(_notification, nullptr);
+    ASSERT_NE(_thermalModeChangedNotification, nullptr);
     _thermalModeChangedNotification->OnThermalModeChanged(IPowerManager::THERMAL_TEMPERATURE_CRITICAL, IPowerManager::THERMAL_TEMPERATURE_HIGH, 48);
 
     EXPECT_EQ(Core::ERROR_NONE, onTemperatureThresholdChanged.Lock());
@@ -1772,7 +1773,7 @@ TEST_F(SystemServicesEventIarmTest, onTemperatureThresholdChangedSuccess_whenHig
             }));
     EVENT_SUBSCRIBE(0, _T("onTemperatureThresholdChanged"), _T("org.rdk.System"), message);
 
-    ASSERT_NE(_notification, nullptr);
+    ASSERT_NE(_thermalModeChangedNotification, nullptr);
     _thermalModeChangedNotification->OnThermalModeChanged(IPowerManager::THERMAL_TEMPERATURE_HIGH, IPowerManager::THERMAL_TEMPERATURE_CRITICAL, 100);
 
     EXPECT_EQ(Core::ERROR_NONE, onTemperatureThresholdChanged.Lock());
@@ -1816,7 +1817,7 @@ TEST_F(SystemServicesEventIarmTest, onTemperatureThresholdChangedSuccess_whenHig
             }));
     EVENT_SUBSCRIBE(0, _T("onTemperatureThresholdChanged"), _T("org.rdk.System"), message);
 
-    ASSERT_NE(_notification, nullptr);
+    ASSERT_NE(_thermalModeChangedNotification, nullptr);
     _thermalModeChangedNotification->OnThermalModeChanged(IPowerManager::THERMAL_TEMPERATURE_HIGH, IPowerManager::THERMAL_TEMPERATURE_NORMAL, 100);
 
     EXPECT_EQ(Core::ERROR_NONE, onTemperatureThresholdChanged.Lock());
@@ -2287,7 +2288,7 @@ TEST_F(SystemServicesEventIarmTest, onSystemPowerStateChanged_From_DEEPSLEEP_to_
 
     EVENT_SUBSCRIBE(0, _T("onSystemPowerStateChanged"), _T("org.rdk.System"), message);
 
-    ASSERT_NE(_notification, nullptr);
+    ASSERT_NE(_modeChangedNotification, nullptr);
     _modeChangedNotification->OnPowerModeChanged(IPowerManager::POWER_STATE_STANDBY_DEEP_SLEEP, IPowerManager::POWER_STATE_ON);
 
     EXPECT_EQ(Core::ERROR_NONE, onSystemPowerStateChanged.Lock());
@@ -2336,7 +2337,7 @@ TEST_F(SystemServicesEventIarmTest, onSystemPowerStateChanged_PowerState_ON_To_L
 
     EVENT_SUBSCRIBE(0, _T("onSystemPowerStateChanged"), _T("org.rdk.System"), message);
 
-    ASSERT_NE(_notification, nullptr);
+    ASSERT_NE(_modeChangedNotification, nullptr);
     _modeChangedNotification->OnPowerModeChanged(IPowerManager::POWER_STATE_ON, IPowerManager::POWER_STATE_STANDBY_LIGHT_SLEEP);
 
     EXPECT_EQ(Core::ERROR_NONE, onSystemPowerStateChanged.Lock());
@@ -2379,7 +2380,7 @@ TEST_F(SystemServicesEventIarmTest, onSystemPowerStateChanged_PowerState_STANDBY
 
     EVENT_SUBSCRIBE(0, _T("onSystemPowerStateChanged"), _T("org.rdk.System"), message);
 
-    ASSERT_NE(_notification, nullptr);
+    ASSERT_NE(_modeChangedNotification, nullptr);
     _modeChangedNotification->OnPowerModeChanged(IPowerManager::POWER_STATE_STANDBY, IPowerManager::POWER_STATE_STANDBY_LIGHT_SLEEP);
 
     EXPECT_EQ(Core::ERROR_NONE, onSystemPowerStateChanged.Lock());
@@ -2440,7 +2441,7 @@ TEST_F(SystemServicesEventIarmTest, onSystemPowerStateChanged_PowerState_ON_To_D
 
     EVENT_SUBSCRIBE(0, _T("onSystemPowerStateChanged"), _T("org.rdk.System"), message);
 
-    ASSERT_NE(_notification, nullptr);
+    ASSERT_NE(_modeChangedNotification, nullptr);
     _modeChangedNotification->OnPowerModeChanged(IPowerManager::POWER_STATE_ON, IPowerManager::POWER_STATE_STANDBY_DEEP_SLEEP);
 
     EXPECT_EQ(Core::ERROR_NONE, onSystemPowerStateChanged.Lock());
@@ -2475,7 +2476,7 @@ TEST_F(SystemServicesEventIarmTest, onNetworkStandbyModeChanged)
 
     EVENT_SUBSCRIBE(0, _T("onNetworkStandbyModeChanged"), _T("org.rdk.System"), message);
 
-    ASSERT_NE(_notification, nullptr);
+    ASSERT_NE(_networkStandbyModeChangedNotification, nullptr);
     _networkStandbyModeChangedNotification->OnNetworkStandbyModeChanged(true);
 
     EXPECT_EQ(Core::ERROR_NONE, onNetworkStandbyModeChanged.Lock());
@@ -2508,7 +2509,7 @@ TEST_F(SystemServicesEventIarmTest, onRebootRequest)
                 return Core::ERROR_NONE;
             }));
 
-    ASSERT_NE(_notification, nullptr);
+    ASSERT_NE(_rebootNotification, nullptr);
     EVENT_SUBSCRIBE(0, _T("onRebootRequest"), _T("org.rdk.System"), message);
     _rebootNotification->OnRebootBegin("reason", "reasonOther", "requestorL1test");
 
@@ -5116,8 +5117,6 @@ TEST_F(SystemServicesEventIarmTest, onSystemModeChanged)
             }));
 
     EVENT_SUBSCRIBE(0, _T("onSystemModeChanged"), _T("org.rdk.System"), message);
-
-    ASSERT_NE(_notification, nullptr);
 
     IARM_Bus_CommonAPI_SysModeChange_Param_t param;
     param.newMode = IARM_BUS_SYS_MODE_NORMAL;

--- a/Tests/L2Tests/CMakeLists.txt
+++ b/Tests/L2Tests/CMakeLists.txt
@@ -19,16 +19,8 @@
 set(PLUGIN_NAME L2TestsDD)
 set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 set(THUNDER_PORT 9998)
-#set(CMAKE_CXX_STANDARD 11)
-find_package(${NAMESPACE}Plugins REQUIRED)
 
-include(FetchContent)
-FetchContent_Declare(
-        googletest
-        URL https://github.com/google/googletest/archive/e39786088138f2749d64e9e90e0f9902daa77c40.zip
-)
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-FetchContent_MakeAvailable(googletest)
+find_package(${NAMESPACE}Plugins REQUIRED)
 
 if(PLUGIN_WAREHOUSE)
     set(SRC_FILES ${SRC_FILES} tests/Warehouse_L2Test.cpp)
@@ -57,7 +49,7 @@ endif()
 add_library(${MODULE_NAME} SHARED ${SRC_FILES})
 
 set_target_properties(${MODULE_NAME} PROPERTIES
-        CXX_STANDARD 11
+        CXX_STANDARD 14
         CXX_STANDARD_REQUIRED YES)
 
 target_compile_definitions(${MODULE_NAME}
@@ -66,7 +58,7 @@ target_compile_definitions(${MODULE_NAME}
             THUNDER_PORT="${THUNDER_PORT}")
 
 target_compile_options(${MODULE_NAME} PRIVATE -Wno-error)
-target_link_libraries(${MODULE_NAME} PRIVATE gmock_main ${NAMESPACE}Plugins::${NAMESPACE}Plugins)
+target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins)
 
 if (NOT L2_TEST_OOP_RPC)
     find_library(TESTMOCKLIB_LIBRARIES NAMES TestMocklib)

--- a/Tests/L2Tests/tests/Warehouse_L2Test.cpp
+++ b/Tests/L2Tests/tests/Warehouse_L2Test.cpp
@@ -26,7 +26,7 @@
 #include <interfaces/IWarehouse.h>
 #include <mutex>
 
-#define JSON_TIMEOUT (6)
+#define JSON_TIMEOUT (1000)
 #define COM_TIMEOUT (100)
 #define TEST_LOG(x, ...)                                                                                                                                        \
     fprintf(stderr, "\033[v_secure_system1;32m[%s:%d](%s)<PID:%d><TID:%d>" x "\n\033[0m", __FILE__, __LINE__, __FUNCTION__, getpid(), gettid(), ##__VA_ARGS__); \
@@ -478,6 +478,7 @@ TEST_F(Warehouse_L2Test, COMRPC_Warehouse_False_Clear_ResetDone)
 ** 3. Subscribe and Triggered resetDone Event
 ** 3. Verify the event Clear resetDone getting triggered using jsonrpc
 *******************************************************/
+
 TEST_F(Warehouse_L2Test, Warehouse_False_Clear_ResetDone)
 {
     JSONRPC::LinkType<Core::JSON::IElement> jsonrpc(WAREHOUSE_CALLSIGN, WAREHOUSEL2TEST_CALLSIGN);
@@ -651,6 +652,7 @@ TEST_F(Warehouse_L2Test, Warehouse_ColdFactory_ResetDone)
 ** 3. Subscribe and Triggered resetDone Event
 ** 3. Verify the event UserFactory resetDone getting triggered using comrpc
 *******************************************************/
+
 TEST_F(Warehouse_L2Test, COMRPC_Warehouse_UserFactory_ResetDone)
 {
     uint32_t status = Core::ERROR_NONE;
@@ -682,6 +684,7 @@ TEST_F(Warehouse_L2Test, COMRPC_Warehouse_UserFactory_ResetDone)
 ** 3. Subscribe and Triggered resetDone Event
 ** 3. Verify the event UserFactory resetDone getting triggered using jsonrpc
 *******************************************************/
+
 TEST_F(Warehouse_L2Test, Warehouse_UserFactory_ResetDone)
 {
     JSONRPC::LinkType<Core::JSON::IElement> jsonrpc(WAREHOUSE_CALLSIGN, WAREHOUSEL2TEST_CALLSIGN);


### PR DESCRIPTION
…rk (#200)

* removed gtest fetchcontent



* removed gtest fetchcontent



* added gtest build job in L1Test yml



* added gtest build job in L2Test yml



* include path for gtest



* include path for gtest



* include path for gtest



* pointing to local branch

* pointing to testframework branch

* comment one test case

* retrigger

* enable systemservices

* comment one test case

* increased timeout

* unceommented the warehouse two test cases

* increased timeout to 1 second

* system services test changes

* pointing to develop

---------