### PR TITLE
RDKEMW-5139:[RDKM-VA-Devices]EntServices : DeviceInfo.modelid, DeviceInfo.make and DeviceInfo.socname APIs return ERROR_GENERAL response.

### DIFF
--- a/DeviceInfo/DeviceInfoJsonRpc.cpp
+++ b/DeviceInfo/DeviceInfoJsonRpc.cpp
@@ -167,13 +167,9 @@ namespace Plugin {
 
         auto result = _deviceInfo->Sku(sku);
         if (result == Core::ERROR_NONE) {
-            Core::EnumerateType<JsonData::DeviceInfo::ModelidData::SkuType> value(sku.c_str(), false);
-            if (value.IsSet()) {
-                response.Sku = value.Value();
-            } else {
-                TRACE(Trace::Fatal, (_T("Unknown value %s"), sku.c_str()));
-                result = Core::ERROR_GENERAL;
-            }
+            response.Sku = sku;
+        } else {
+            TRACE(Trace::Fatal, (_T("SKU wasn't specified.")));
         }
 
         return result;
@@ -189,13 +185,9 @@ namespace Plugin {
 
         auto result = _deviceInfo->Make(make);
         if (result == Core::ERROR_NONE) {
-            Core::EnumerateType<JsonData::DeviceInfo::MakeData::MakeType> value(make.c_str(), false);
-            if (value.IsSet()) {
-                response.Make = value.Value();
-            } else {
-                TRACE(Trace::Fatal, (_T("Unknown value %s"), make.c_str()));
-                result = Core::ERROR_GENERAL;
-            }
+            response.Make = make;
+        } else {
+            TRACE(Trace::Fatal, (_T("Make wasn't specified.")));
         }
 
         return result;
@@ -266,13 +258,7 @@ namespace Plugin {
         auto result = _deviceInfo->SocName(socType);
 
         if (result == Core::ERROR_NONE) {
-            Core::EnumerateType<JsonData::DeviceInfo::SocnameData::SocnameType> value(socType.c_str(), false);
-            if (value.IsSet()) {
-                response.Socname = value.Value();
-            } else {
-                TRACE(Trace::Fatal, (_T("Unknown value %s"), socType.c_str()));
-                result = Core::ERROR_GENERAL;
-            }
+            response.Socname = socType;
         } else {
             TRACE(Trace::Fatal, (_T("Socname wasn't specified.")));
         }

--- a/DeviceInfo/Implementation/DeviceInfo.cpp
+++ b/DeviceInfo/Implementation/DeviceInfo.cpp
@@ -166,11 +166,6 @@ namespace Plugin {
         return result;
     }
 
-#if defined(MACHINE_SOC_NAME)
-#define xsocstr(s) lsocstr(s)
-#define lsocstr(s) #s
-#endif
-
     uint32_t DeviceInfoImplementation::SocName(string& socName)  const
     {
         return (GetFileRegex(_T("/etc/device.properties"),


### PR DESCRIPTION
**Reason for change:** Refactor to remove the check for enum and Returns the what is returned from MFR or device.properties.
**Test Procedure:** Build and verify
**Risks**: High.
**Signed-off-by:** sundaramuneeswaran_muthuraj@comcast.com