### PR TITLE
Resolve Warehouse L2 Test Case failure

### DIFF
--- a/Tests/L2Tests/tests/Warehouse_L2Test.cpp
+++ b/Tests/L2Tests/tests/Warehouse_L2Test.cpp
@@ -202,6 +202,8 @@ Warehouse_L2Test::~Warehouse_L2Test()
     /* Deactivate plugin in destructor */
     status = DeactivateService("org.rdk.Warehouse");
     EXPECT_EQ(Core::ERROR_NONE, status);
+
+    sleep(3);
 }
 
 /**

--- a/Tests/L2Tests/tests/Warehouse_L2Test.cpp
+++ b/Tests/L2Tests/tests/Warehouse_L2Test.cpp
@@ -1595,6 +1595,7 @@ TEST_F(Warehouse_L2Test, Warehouse_False_Clear_ResetDevice)
 {
     JSONRPC::LinkType<Core::JSON::IElement> jsonrpc(WAREHOUSE_CALLSIGN, WAREHOUSEL2TEST_CALLSIGN);
     StrictMock<AsyncHandlerMock_Warehouse> async_handler;
+    uint32_t signalled = WAREHOUSEL2TEST_STATE_INVALID;
     uint32_t status = Core::ERROR_GENERAL;
     JsonObject params;
     JsonObject result;
@@ -1607,6 +1608,22 @@ TEST_F(Warehouse_L2Test, Warehouse_False_Clear_ResetDevice)
 
     /* Activate plugin in TEST_F*/
     status = ActivateService("org.rdk.Warehouse");
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    message = "{\"success\":true,\"error\":\"\"}";
+    expected_status.FromString(message);
+    EXPECT_CALL(async_handler, resetDone(MatchRequest(expected_status)))
+        .WillOnce(Invoke(this, &Warehouse_L2Test::resetDone));
+
+    /* errorCode and errorDescription should not be set */
+    EXPECT_FALSE(result.HasLabel("errorCode"));
+    EXPECT_FALSE(result.HasLabel("errorDescription"));
+
+    /* Register for resetDone event. */
+    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
+        _T("resetDone"),
+        &AsyncHandlerMock_Warehouse::resetDone,
+        &async_handler);
     EXPECT_EQ(Core::ERROR_NONE, status);
 
     EXPECT_CALL(*p_wrapsImplMock, v_secure_system(::testing::_, ::testing::_))
@@ -1622,6 +1639,12 @@ TEST_F(Warehouse_L2Test, Warehouse_False_Clear_ResetDevice)
     status = InvokeServiceMethod("org.rdk.Warehouse.1", "resetDevice", params, result);
     EXPECT_EQ(Core::ERROR_NONE, status);
     EXPECT_TRUE(result["success"].Boolean());
+
+    signalled = WaitForRequestStatus(JSON_TIMEOUT, WAREHOUSEL2TEST_RESETDONE);
+    EXPECT_TRUE(signalled & WAREHOUSEL2TEST_RESETDONE);
+
+    /* Unregister for events. */
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("resetDone"));
 }
 
 /********************************************************

--- a/Tests/L2Tests/tests/Warehouse_L2Test.cpp
+++ b/Tests/L2Tests/tests/Warehouse_L2Test.cpp
@@ -506,7 +506,6 @@ TEST_F(Warehouse_L2Test, Warehouse_False_Clear_ResetDone)
 {
     JSONRPC::LinkType<Core::JSON::IElement> jsonrpc(WAREHOUSE_CALLSIGN, WAREHOUSEL2TEST_CALLSIGN);
     StrictMock<AsyncHandlerMock_Warehouse> async_handler;
-    uint32_t signalled = WAREHOUSEL2TEST_STATE_INVALID;
     uint32_t status = Core::ERROR_GENERAL;
     JsonObject params;
     JsonObject result;

--- a/Tests/L2Tests/tests/Warehouse_L2Test.cpp
+++ b/Tests/L2Tests/tests/Warehouse_L2Test.cpp
@@ -299,6 +299,7 @@ TEST_F(Warehouse_L2Test, COMRPC_Warehouse_Clear_True_ResetDone)
     uint32_t status = Core::ERROR_NONE;
 
     EXPECT_CALL(*p_wrapsImplMock, v_secure_system(::testing::_, ::testing::_))
+        .Times(::testing::AnyNumber())
         .WillOnce(::testing::Invoke(
             [](const char* command, va_list args) {
                 EXPECT_EQ(string(command), string("sh /lib/rdk/deviceReset.sh WAREHOUSE_CLEAR --suppressReboot"));
@@ -329,6 +330,7 @@ TEST_F(Warehouse_L2Test, Warehouse_Clear_True_ResetDone)
     JsonObject expected_status;
 
     EXPECT_CALL(*p_wrapsImplMock, v_secure_system(::testing::_, ::testing::_))
+        .Times(::testing::AnyNumber())
         .WillOnce(::testing::Invoke(
             [](const char* command, va_list args) {
                 EXPECT_EQ(string(command), string("sh /lib/rdk/deviceReset.sh WAREHOUSE_CLEAR --suppressReboot"));

--- a/Tests/L2Tests/tests/Warehouse_L2Test.cpp
+++ b/Tests/L2Tests/tests/Warehouse_L2Test.cpp
@@ -299,7 +299,6 @@ TEST_F(Warehouse_L2Test, COMRPC_Warehouse_Clear_True_ResetDone)
     uint32_t status = Core::ERROR_NONE;
 
     EXPECT_CALL(*p_wrapsImplMock, v_secure_system(::testing::_, ::testing::_))
-        .Times(1)
         .WillOnce(::testing::Invoke(
             [](const char* command, va_list args) {
                 EXPECT_EQ(string(command), string("sh /lib/rdk/deviceReset.sh WAREHOUSE_CLEAR --suppressReboot"));

--- a/Tests/L2Tests/tests/Warehouse_L2Test.cpp
+++ b/Tests/L2Tests/tests/Warehouse_L2Test.cpp
@@ -323,12 +323,29 @@ TEST_F(Warehouse_L2Test, Warehouse_Clear_True_ResetDone)
 {
     JSONRPC::LinkType<Core::JSON::IElement> jsonrpc(WAREHOUSE_CALLSIGN, WAREHOUSEL2TEST_CALLSIGN);
     StrictMock<AsyncHandlerMock_Warehouse> async_handler;
+    uint32_t signalled = WAREHOUSEL2TEST_STATE_INVALID;
     uint32_t status = Core::ERROR_GENERAL;
     JsonObject params;
     JsonObject result;
     std::string message;
     JsonObject expected_status;
 
+    /* errorCode and errorDescription should not be set */
+    EXPECT_FALSE(result.HasLabel("errorCode"));
+    EXPECT_FALSE(result.HasLabel("errorDescription"));
+
+    /* Register for resetDone event. */
+    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
+        _T("resetDone"),
+        &AsyncHandlerMock_Warehouse::resetDone,
+        &async_handler);
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    message = "{\"success\":true,\"error\":\"\"}";
+    expected_status.FromString(message);
+    EXPECT_CALL(async_handler, resetDone(MatchRequest(expected_status)))
+        .WillOnce(Invoke(this, &Warehouse_L2Test::resetDone));
+    
     EXPECT_CALL(*p_wrapsImplMock, v_secure_system(::testing::_, ::testing::_))
         .Times(1)
         .WillOnce(::testing::Invoke(
@@ -347,6 +364,12 @@ TEST_F(Warehouse_L2Test, Warehouse_Clear_True_ResetDone)
     status = InvokeServiceMethod("org.rdk.Warehouse.1", "resetDevice", params, result);
     EXPECT_EQ(Core::ERROR_NONE, status);
     EXPECT_TRUE(result["success"].Boolean());
+
+     signalled = WaitForRequestStatus(JSON_TIMEOUT, WAREHOUSEL2TEST_RESETDONE);
+    EXPECT_TRUE(signalled & WAREHOUSEL2TEST_RESETDONE);
+
+    /* Unregister for events. */
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("resetDone"));
 }
 
 /********************************************************
@@ -483,6 +506,7 @@ TEST_F(Warehouse_L2Test, Warehouse_False_Clear_ResetDone)
 {
     JSONRPC::LinkType<Core::JSON::IElement> jsonrpc(WAREHOUSE_CALLSIGN, WAREHOUSEL2TEST_CALLSIGN);
     StrictMock<AsyncHandlerMock_Warehouse> async_handler;
+    uint32_t signalled = WAREHOUSEL2TEST_STATE_INVALID;
     uint32_t status = Core::ERROR_GENERAL;
     JsonObject params;
     JsonObject result;
@@ -1523,6 +1547,7 @@ TEST_F(Warehouse_L2Test, Warehouse_UserFactory_ResetDevice)
 {
     JSONRPC::LinkType<Core::JSON::IElement> jsonrpc(WAREHOUSE_CALLSIGN, WAREHOUSEL2TEST_CALLSIGN);
     StrictMock<AsyncHandlerMock_Warehouse> async_handler;
+    uint32_t signalled = WAREHOUSEL2TEST_STATE_INVALID;
     uint32_t status = Core::ERROR_GENERAL;
     JsonObject params;
     JsonObject result;
@@ -1537,6 +1562,22 @@ TEST_F(Warehouse_L2Test, Warehouse_UserFactory_ResetDevice)
     status = ActivateService("org.rdk.Warehouse");
     EXPECT_EQ(Core::ERROR_NONE, status);
 
+    /* errorCode and errorDescription should not be set */
+    EXPECT_FALSE(result.HasLabel("errorCode"));
+    EXPECT_FALSE(result.HasLabel("errorDescription"));
+
+    /* Register for resetDone event. */
+    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
+        _T("resetDone"),
+        &AsyncHandlerMock_Warehouse::resetDone,
+        &async_handler);
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    message = "{\"success\":true,\"error\":\"\"}";
+    expected_status.FromString(message);
+    EXPECT_CALL(async_handler, resetDone(MatchRequest(expected_status)))
+        .WillOnce(Invoke(this, &Warehouse_L2Test::resetDone));
+
     EXPECT_CALL(*p_wrapsImplMock, v_secure_system(::testing::_, ::testing::_))
         .Times(1)
         .WillOnce(::testing::Invoke(
@@ -1550,6 +1591,12 @@ TEST_F(Warehouse_L2Test, Warehouse_UserFactory_ResetDevice)
     status = InvokeServiceMethod("org.rdk.Warehouse.1", "resetDevice", params, result);
     EXPECT_EQ(Core::ERROR_NONE, status);
     EXPECT_TRUE(result["success"].Boolean());
+
+    signalled = WaitForRequestStatus(JSON_TIMEOUT, WAREHOUSEL2TEST_RESETDONE);
+    EXPECT_TRUE(signalled & WAREHOUSEL2TEST_RESETDONE);
+
+    /* Unregister for events. */
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("resetDone"));
 }
 
 /********************************************************

--- a/Tests/L2Tests/tests/Warehouse_L2Test.cpp
+++ b/Tests/L2Tests/tests/Warehouse_L2Test.cpp
@@ -328,7 +328,7 @@ TEST_F(Warehouse_L2Test, Warehouse_Clear_True_ResetDone)
     JsonObject result;
     std::string message;
     JsonObject expected_status;
-    
+
     EXPECT_CALL(*p_wrapsImplMock, v_secure_system(::testing::_, ::testing::_))
         .Times(1)
         .WillOnce(::testing::Invoke(

--- a/Tests/L2Tests/tests/Warehouse_L2Test.cpp
+++ b/Tests/L2Tests/tests/Warehouse_L2Test.cpp
@@ -330,7 +330,6 @@ TEST_F(Warehouse_L2Test, Warehouse_Clear_True_ResetDone)
     JsonObject expected_status;
 
     EXPECT_CALL(*p_wrapsImplMock, v_secure_system(::testing::_, ::testing::_))
-        .Times(1)
         .WillOnce(::testing::Invoke(
             [](const char* command, va_list args) {
                 EXPECT_EQ(string(command), string("sh /lib/rdk/deviceReset.sh WAREHOUSE_CLEAR --suppressReboot"));

--- a/Tests/L2Tests/tests/Warehouse_L2Test.cpp
+++ b/Tests/L2Tests/tests/Warehouse_L2Test.cpp
@@ -199,6 +199,14 @@ Warehouse_L2Test::~Warehouse_L2Test()
         m_warehouseplugin->Release();
     }
 
+    //Just make sure the mock instance is removed for fresh mock obj for next fixture run
+    if(p_wrapsImplMock != nullptr)
+    {
+        Wraps::setImpl(nullptr);
+        delete p_wrapsImplMock;
+        p_wrapsImplMock = nullptr;
+    }
+
     /* Deactivate plugin in destructor */
     status = DeactivateService("org.rdk.Warehouse");
     EXPECT_EQ(Core::ERROR_NONE, status);

--- a/Tests/L2Tests/tests/Warehouse_L2Test.cpp
+++ b/Tests/L2Tests/tests/Warehouse_L2Test.cpp
@@ -202,14 +202,6 @@ Warehouse_L2Test::~Warehouse_L2Test()
     /* Deactivate plugin in destructor */
     status = DeactivateService("org.rdk.Warehouse");
     EXPECT_EQ(Core::ERROR_NONE, status);
-
-    //Just make sure the mock instance is removed for fresh mock obj for next fixture run
-    if(p_wrapsImplMock != nullptr)
-    {
-        Wraps::setImpl(nullptr);
-        delete p_wrapsImplMock;
-        p_wrapsImplMock = nullptr;
-    }
 }
 
 /**

--- a/Tests/L2Tests/tests/Warehouse_L2Test.cpp
+++ b/Tests/L2Tests/tests/Warehouse_L2Test.cpp
@@ -302,7 +302,7 @@ TEST_F(Warehouse_L2Test, COMRPC_Warehouse_Clear_True_ResetDone)
         .Times(::testing::AnyNumber())
         .WillOnce(::testing::Invoke(
             [](const char* command, va_list args) {
-                EXPECT_EQ(string(command), string("sh /lib/rdk/deviceReset.sh WAREHOUSE_CLEAR --suppressReboot &"));
+                EXPECT_EQ(string(command), string("sh /lib/rdk/deviceReset.sh WAREHOUSE_CLEAR --suppressReboot"));
                 return Core::ERROR_NONE;
             }));
 
@@ -333,7 +333,7 @@ TEST_F(Warehouse_L2Test, Warehouse_Clear_True_ResetDone)
         .Times(::testing::AnyNumber())
         .WillOnce(::testing::Invoke(
             [](const char* command, va_list args) {
-                EXPECT_EQ(string(command), string("sh /lib/rdk/deviceReset.sh WAREHOUSE_CLEAR --suppressReboot &"));
+                EXPECT_EQ(string(command), string("sh /lib/rdk/deviceReset.sh WAREHOUSE_CLEAR --suppressReboot"));
                 return Core::ERROR_NONE;
             }));
 

--- a/Tests/L2Tests/tests/Warehouse_L2Test.cpp
+++ b/Tests/L2Tests/tests/Warehouse_L2Test.cpp
@@ -302,7 +302,7 @@ TEST_F(Warehouse_L2Test, COMRPC_Warehouse_Clear_True_ResetDone)
         .Times(::testing::AnyNumber())
         .WillOnce(::testing::Invoke(
             [](const char* command, va_list args) {
-                EXPECT_EQ(string(command), string("sh /lib/rdk/deviceReset.sh WAREHOUSE_CLEAR --suppressReboot"));
+                EXPECT_EQ(string(command), string("sh /lib/rdk/deviceReset.sh WAREHOUSE_CLEAR --suppressReboot &"));
                 return Core::ERROR_NONE;
             }));
 
@@ -333,7 +333,7 @@ TEST_F(Warehouse_L2Test, Warehouse_Clear_True_ResetDone)
         .Times(::testing::AnyNumber())
         .WillOnce(::testing::Invoke(
             [](const char* command, va_list args) {
-                EXPECT_EQ(string(command), string("sh /lib/rdk/deviceReset.sh WAREHOUSE_CLEAR --suppressReboot"));
+                EXPECT_EQ(string(command), string("sh /lib/rdk/deviceReset.sh WAREHOUSE_CLEAR --suppressReboot &"));
                 return Core::ERROR_NONE;
             }));
 

--- a/Tests/L2Tests/tests/Warehouse_L2Test.cpp
+++ b/Tests/L2Tests/tests/Warehouse_L2Test.cpp
@@ -323,28 +323,11 @@ TEST_F(Warehouse_L2Test, Warehouse_Clear_True_ResetDone)
 {
     JSONRPC::LinkType<Core::JSON::IElement> jsonrpc(WAREHOUSE_CALLSIGN, WAREHOUSEL2TEST_CALLSIGN);
     StrictMock<AsyncHandlerMock_Warehouse> async_handler;
-    uint32_t signalled = WAREHOUSEL2TEST_STATE_INVALID;
     uint32_t status = Core::ERROR_GENERAL;
     JsonObject params;
     JsonObject result;
     std::string message;
     JsonObject expected_status;
-
-    /* errorCode and errorDescription should not be set */
-    EXPECT_FALSE(result.HasLabel("errorCode"));
-    EXPECT_FALSE(result.HasLabel("errorDescription"));
-
-    /* Register for resetDone event. */
-    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
-        _T("resetDone"),
-        &AsyncHandlerMock_Warehouse::resetDone,
-        &async_handler);
-    EXPECT_EQ(Core::ERROR_NONE, status);
-
-    message = "{\"success\":true,\"error\":\"\"}";
-    expected_status.FromString(message);
-    EXPECT_CALL(async_handler, resetDone(MatchRequest(expected_status)))
-        .WillOnce(Invoke(this, &Warehouse_L2Test::resetDone));
     
     EXPECT_CALL(*p_wrapsImplMock, v_secure_system(::testing::_, ::testing::_))
         .Times(1)
@@ -364,12 +347,6 @@ TEST_F(Warehouse_L2Test, Warehouse_Clear_True_ResetDone)
     status = InvokeServiceMethod("org.rdk.Warehouse.1", "resetDevice", params, result);
     EXPECT_EQ(Core::ERROR_NONE, status);
     EXPECT_TRUE(result["success"].Boolean());
-
-     signalled = WaitForRequestStatus(JSON_TIMEOUT, WAREHOUSEL2TEST_RESETDONE);
-    EXPECT_TRUE(signalled & WAREHOUSEL2TEST_RESETDONE);
-
-    /* Unregister for events. */
-    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("resetDone"));
 }
 
 /********************************************************

--- a/Tests/L2Tests/tests/Warehouse_L2Test.cpp
+++ b/Tests/L2Tests/tests/Warehouse_L2Test.cpp
@@ -199,6 +199,10 @@ Warehouse_L2Test::~Warehouse_L2Test()
         m_warehouseplugin->Release();
     }
 
+    /* Deactivate plugin in destructor */
+    status = DeactivateService("org.rdk.Warehouse");
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
     //Just make sure the mock instance is removed for fresh mock obj for next fixture run
     if(p_wrapsImplMock != nullptr)
     {
@@ -206,10 +210,6 @@ Warehouse_L2Test::~Warehouse_L2Test()
         delete p_wrapsImplMock;
         p_wrapsImplMock = nullptr;
     }
-
-    /* Deactivate plugin in destructor */
-    status = DeactivateService("org.rdk.Warehouse");
-    EXPECT_EQ(Core::ERROR_NONE, status);
 }
 
 /**


### PR DESCRIPTION
Resolving the L2 Test failure for Warehouse plugin in entservices-testframework