### PR TITLE
RDKEMW-6513:Adding Missing APIs for DisplaySettings

### DIFF
--- a/.github/workflows/L2-tests.yml
+++ b/.github/workflows/L2-tests.yml
@@ -87,7 +87,8 @@ jobs:
         with:
           repository: rdkcentral/entservices-deviceanddisplay
           path: entservices-deviceanddisplay
-          ref: develop
+          # ref: develop
+          ref: topic/RDKEMW-6513-IUI-CT-DD
 
       - name: Checkout entservices-testframework
         uses: actions/checkout@v3

--- a/Tests/L2Tests/tests/DisplaySettings_L2Test.cpp
+++ b/Tests/L2Tests/tests/DisplaySettings_L2Test.cpp
@@ -101,6 +101,7 @@ TEST_F(DisplaySettings_L2test, DisplaySettings_L2_MethodTest)
     string videoPort(_T("HDMI0"));
     string audioPort(_T("HDMI0"));
 
+    device::AudioOutputPort audioOutputPort;
     device::VideoOutputPort videoOutputPort;
     device::VideoDevice videoDevice;
     device::VideoResolution videoResolution;
@@ -310,6 +311,97 @@ TEST_F(DisplaySettings_L2test, DisplaySettings_L2_MethodTest)
     {
         JsonObject result, params;
         status = InvokeServiceMethod("org.rdk.DisplaySettings.1", "getSinkAtmosCapability", params, result);
+    }
+
+    /************************getSupportedMS12Config***************************/
+    {
+        JsonObject result, params;
+        status = InvokeServiceMethod("org.rdk.DisplaySettings.1", "getSupportedMS12Config", params, result);
+    }
+
+    /************************getVolumeLeveller***************************/
+
+    ON_CALL(*p_hostImplMock, getAudioOutputPort(::testing::_))
+        .WillByDefault(::testing::ReturnRef(audioOutputPort));
+
+    {
+        JsonObject result, params5;
+        params5["audioPort"] = "SPEAKER0";
+        status = InvokeServiceMethod("org.rdk.DisplaySettings.1", "getVolumeLeveller", params5, result);
+    }
+
+    /************************resetBassEnhancer***************************/
+
+    ON_CALL(*p_hostImplMock, getAudioOutputPort(::testing::_))
+        .WillByDefault(::testing::ReturnRef(audioOutputPort));
+    {
+        JsonObject result, params6;
+        params6["audioPort"] = "SPEAKER0";
+        status = InvokeServiceMethod("org.rdk.DisplaySettings.1", "resetBassEnhancer", params6, result);
+    }
+
+    /************************resetVolumeLeveller***************************/
+
+    ON_CALL(*p_hostImplMock, getAudioOutputPort(::testing::_))
+        .WillByDefault(::testing::ReturnRef(audioOutputPort));
+    {
+        JsonObject result, params7;
+        params7["audioPort"] = "SPEAKER0";
+        status = InvokeServiceMethod("org.rdk.DisplaySettings.1", "resetVolumeLeveller", params7, result);
+    }
+    
+    /************************getBassEnhancer***************************/
+
+    ON_CALL(*p_hostImplMock, getAudioOutputPort(::testing::_))
+        .WillByDefault(::testing::ReturnRef(audioOutputPort));
+
+    ON_CALL(*p_audioOutputPortMock, isConnected())
+        .WillByDefault(::testing::Return(true));
+
+    ON_CALL(*p_audioOutputPortMock, getBassEnhancer())
+        .WillByDefault(::testing::Return(50));
+
+    {
+        JsonObject params3, result;
+        params3["audioPort"] = "SPEAKER0";
+        status = InvokeServiceMethod("org.rdk.DisplaySettings.1", "getBassEnhancer", params3, result);
+    }
+
+    /************************getSurroundVirtualizer***************************/
+
+    dsSurroundVirtualizer_t mockVirtualizer;
+    mockVirtualizer.mode = 1;
+    mockVirtualizer.boost = 90;
+
+    ON_CALL(*p_hostImplMock, getAudioOutputPort(::testing::_))
+        .WillByDefault(::testing::ReturnRef(audioOutputPort));
+
+    ON_CALL(*p_audioOutputPortMock, isConnected())
+        .WillByDefault(::testing::Return(true));
+
+    ON_CALL(*p_audioOutputPortMock, getSurroundVirtualizer())
+        .WillByDefault(::testing::Return(mockVirtualizer));
+
+    {
+        JsonObject result, params4;
+        params4["audioPort"] = "SPEAKER0";
+        status = InvokeServiceMethod("org.rdk.DisplaySettings.1", "getSurroundVirtualizer", params4, result);
+    }
+
+    /************************setVolumeLeveller***************************/
+
+    ON_CALL(*p_hostImplMock, getAudioOutputPort(::testing::_))
+        .WillByDefault(::testing::ReturnRef(audioOutputPort));
+
+    ON_CALL(*p_audioOutputPortMock, isConnected())
+        .WillByDefault(::testing::Return(true));
+
+    {
+        JsonObject result, params8;
+        params8["audioPort"] = "SPEAKER0";
+        params8["mode"] = "1";
+        params8["level"] = "9";
+        status = InvokeServiceMethod("org.rdk.DisplaySettings.1", "setVolumeLeveller", params8, result);
     }
 
 }


### PR DESCRIPTION
Reason for change: Resolving the DisplaySetting Crash issue
Test Procedure: Regression
Risks: Low
Priority: P1