### PR TITLE
RDKEMW-8575: SafetyCheck to avoid crash on SystemService

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -3021,6 +3021,7 @@ namespace WPEFramework {
 	uint32_t SystemServices::setTerritory(const JsonObject& parameters, JsonObject& response)
 	{
 		bool resp = false;
+		const std::lock_guard<std::mutex> lock(m_territoryMutex);
 		if(parameters.HasLabel("territory")){
 			makePersistentDir();
 			string regionStr = "";
@@ -3098,6 +3099,7 @@ namespace WPEFramework {
 	uint32_t SystemServices::getTerritory(const JsonObject& parameters, JsonObject& response)
 	{
 		bool resp = true;
+		const std::lock_guard<std::mutex> lock(m_territoryMutex);
 		m_strTerritory = "";
 		m_strRegion = "";
 		resp = readTerritoryFromFile();

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -3105,6 +3105,15 @@ namespace WPEFramework {
 		response["region"] = m_strRegion;
 		returnResponse(resp);
 	}
+    string SystemServices::safeExtractAfterColon(const std::string& inputLine) {
+	     size_t pos = inputLine.find(':');
+         if ((pos != std::string::npos) && (pos + 1 < inputLine.length())) {
+             return inputLine.substr(pos + 1);
+          } else {
+             LOGERR("Territory file corrupted");  
+           }
+           return "";
+	}
 
 	bool SystemServices::readTerritoryFromFile()
 	{
@@ -3116,12 +3125,12 @@ namespace WPEFramework {
 			    getline (inFile, str);
 			    if(str.length() > 0){
 			    	retValue = true;
-			    	m_strTerritory = str.substr(str.find(":")+1,str.length());
+			    	m_strTerritory = safeExtractAfterColon(str);
 			    	int index = m_strStandardTerritoryList.find(m_strTerritory);
 			    	if((m_strTerritory.length() == 3) && (index >=0 && index <= 1100) ){
 			    		getline (inFile, str);
 			    		if(str.length() > 0){
-			    		    m_strRegion = str.substr(str.find(":")+1,str.length());
+			    		    m_strRegion = safeExtractAfterColon(str);
 			    		    if(!isRegionValid(m_strRegion))
 			    		    {
 			    			    m_strTerritory = "";

--- a/SystemServices/SystemServices.h
+++ b/SystemServices/SystemServices.h
@@ -226,6 +226,7 @@ namespace WPEFramework {
 #endif
                 pid_t m_uploadLogsPid;
                 std::mutex m_uploadLogsMutex;
+                std::mutex m_territoryMutex;
                 PowerManagerInterfaceRef _powerManagerPlugin;
                 Core::Sink<PowerManagerNotification> _pwrMgrNotification;
                 bool _registeredEventHandlers;

--- a/SystemServices/SystemServices.h
+++ b/SystemServices/SystemServices.h
@@ -258,6 +258,7 @@ namespace WPEFramework {
                 std::string getStbTimestampString();
 		std::string getStbBranchString();
                 bool makePersistentDir();
+                std::string safeExtractAfterColon(const std::string& inputLine);
 
 #if defined(USE_IARMBUS) || defined(USE_IARM_BUS)
                 void InitializeIARM();


### PR DESCRIPTION
This PR is to add safetycheck around string manipulation to ensure that systemservice wont crash. Changes already added in rdk-v and same fix added here as well