### PR TITLE
RDKEMW-15264: Bring 3.1.18, 3.1.19 changes to support/8.3.4.0 to entservices-deviceanddisplay

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -856,6 +856,24 @@ namespace WPEFramework {
             }
         }
 
+        int DisplaySettings::getAudioDeviceSADState(void) {
+            //function used to read the current SAD state with lock
+            std::lock_guard<std::mutex> lock(m_SadMutex);
+            return m_AudioDeviceSADState;
+        }
+
+        void DisplaySettings::setAudioDeviceSADState(int newState) {
+            // function used to set the required SAD state with lock
+            std::lock_guard<std::mutex> lock(m_SadMutex);
+            LOGINFO("Updating m_AudioDeviceSADState : %d", newState);
+            m_AudioDeviceSADState = newState;
+        }
+
+        int DisplaySettings::getCurrentArcRoutingState(void) {
+            std::lock_guard<std::mutex> lock(m_AudioDeviceStatesUpdateMutex);
+            return m_currentArcRoutingState;
+        }
+
         void DisplaySettings::dsHdmiEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
         {
             switch (eventId)
@@ -4389,9 +4407,9 @@ namespace WPEFramework {
 					if ((mode == device::AudioStereoMode::kPassThru)  || (aPort.getStereoAuto() == true))
 					{
 					  {
-					    std::lock_guard<std::mutex> lock(m_SadMutex);
 					    /* Take actions according to SAD udpate state */
-					    switch(m_AudioDeviceSADState)
+                        int currentSADState = getAudioDeviceSADState();
+					    switch(currentSADState)
 					    {
 						case  AUDIO_DEVICE_SAD_UPDATED: 						   
 						{
@@ -4404,7 +4422,7 @@ namespace WPEFramework {
 						case AUDIO_DEVICE_SAD_RECEIVED: 
 						{
 							LOGINFO("%s: Update Audio device SAD\n", __FUNCTION__);
-							m_AudioDeviceSADState = AUDIO_DEVICE_SAD_UPDATED;
+							setAudioDeviceSADState(AUDIO_DEVICE_SAD_UPDATED);
 							aPort.setSAD(sad_list);
 
 							if(aPort.getStereoAuto() == true) {
@@ -4435,7 +4453,7 @@ namespace WPEFramework {
 											
 						default: 
 						{
-							LOGINFO("Incorrect Audio Deivce SAD state %d\n", m_AudioDeviceSADState); // should not hit this case
+							LOGINFO("Incorrect Audio Deivce SAD state %d\n", currentSADState); // should not hit this case
 						}
 						break;
 					    }
@@ -4936,9 +4954,10 @@ void DisplaySettings::sendMsgThread()
                 LOGERR("Field 'status' could not be found in the event's payload.");
                 return;
             }
-	    LOGINFO("ARC routing state before update m_currentArcRoutingState=%d\n ", m_currentArcRoutingState);
+            int currentrcRoutingState = getCurrentArcRoutingState();
+	    LOGINFO("ARC routing state before update m_currentArcRoutingState=%d\n ", currentrcRoutingState);
 	    // AVR power status is not checked here assuming that ARC init request will happen only when AVR is in ON state
-            if ((m_currentArcRoutingState != ARC_STATE_ARC_INITIATED) && (m_systemAudioMode_Power_RequestedAndReceived == true)) {
+            if ((currentrcRoutingState != ARC_STATE_ARC_INITIATED) && (m_systemAudioMode_Power_RequestedAndReceived == true)) {
                 value = parameters["status"].String();
 
 		if( !value.compare("success") ) {
@@ -5018,8 +5037,9 @@ void DisplaySettings::sendMsgThread()
 		LOGINFO("SAD already cleared\n");
 	    }
 
-	    LOGINFO("Current ARC routing state before update m_currentArcRoutingState=%d\n ", m_currentArcRoutingState);
-	    if (m_currentArcRoutingState != ARC_STATE_ARC_TERMINATED) {
+        int currentrcRoutingState = getCurrentArcRoutingState();
+	    LOGINFO("Current ARC routing state before update m_currentArcRoutingState=%d\n ", currentrcRoutingState);
+	    if (currentrcRoutingState != ARC_STATE_ARC_TERMINATED) {
                 if (parameters.HasLabel("status")) {
                     value = parameters["status"].String();
                     std::lock_guard<std::mutex> lock(m_AudioDeviceStatesUpdateMutex);
@@ -5066,11 +5086,11 @@ void DisplaySettings::sendMsgThread()
 
             if (parameters.HasLabel("ShortAudioDescriptor")) {
                 shortAudioDescriptorList = parameters["ShortAudioDescriptor"].Array();
-		if (m_AudioDeviceSADState == AUDIO_DEVICE_SAD_REQUESTED) {
+                int currentSADState = getAudioDeviceSADState();
+		if (currentSADState == AUDIO_DEVICE_SAD_REQUESTED) {
                     try
                     {
-		        std::lock_guard<std::mutex> lock(m_SadMutex);
-			m_AudioDeviceSADState = AUDIO_DEVICE_SAD_RECEIVED;
+            setAudioDeviceSADState(AUDIO_DEVICE_SAD_RECEIVED);
 			m_requestSadRetrigger = false;
                         device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort("HDMI_ARC0");
 			LOGINFO("Total Short Audio Descriptors received from connected ARC device: %d\n",shortAudioDescriptorList.Length());
@@ -5097,7 +5117,7 @@ void DisplaySettings::sendMsgThread()
 
 			    if (wasSADTimerActive == true && m_arcEarcAudioEnabled == false ) { /*setEnableAudioPort is called, Timer has started, got SAD before Timer Expiry*/
 			        LOGINFO("%s: Updating SAD \n", __FUNCTION__);
-                                m_AudioDeviceSADState = AUDIO_DEVICE_SAD_UPDATED;
+                                setAudioDeviceSADState(AUDIO_DEVICE_SAD_UPDATED);
                                 aPort.setSAD(sad_list);
                                 if(aPort.getStereoAuto() == true) {
                                     aPort.setStereoAuto(true,true);
@@ -5113,7 +5133,7 @@ void DisplaySettings::sendMsgThread()
                         	m_arcEarcAudioEnabled = true;
 			    } else if (m_arcEarcAudioEnabled == true) { /*setEnableAudioPort is called,Timer started and Expired, arc is routed -- or for both wasSADTimerActive == true/false*/
 				LOGINFO("%s: Updating SAD since audio is already routed and ARC is initiated\n", __FUNCTION__);
-				 m_AudioDeviceSADState = AUDIO_DEVICE_SAD_UPDATED;
+				setAudioDeviceSADState(AUDIO_DEVICE_SAD_UPDATED);
 				    aPort.setSAD(sad_list);
                         	    if(aPort.getStereoAuto() == true) {
                     	            	aPort.setStereoAuto(true,true);

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -4954,10 +4954,10 @@ void DisplaySettings::sendMsgThread()
                 LOGERR("Field 'status' could not be found in the event's payload.");
                 return;
             }
-            int currentrcRoutingState = getCurrentArcRoutingState();
-	    LOGINFO("ARC routing state before update m_currentArcRoutingState=%d\n ", currentrcRoutingState);
+            int currentArcRoutingState = getCurrentArcRoutingState();
+	    LOGINFO("ARC routing state before update m_currentArcRoutingState=%d\n ", currentArcRoutingState);
 	    // AVR power status is not checked here assuming that ARC init request will happen only when AVR is in ON state
-            if ((currentrcRoutingState != ARC_STATE_ARC_INITIATED) && (m_systemAudioMode_Power_RequestedAndReceived == true)) {
+            if ((currentArcRoutingState != ARC_STATE_ARC_INITIATED) && (m_systemAudioMode_Power_RequestedAndReceived == true)) {
                 value = parameters["status"].String();
 
 		if( !value.compare("success") ) {

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -4453,7 +4453,7 @@ namespace WPEFramework {
 											
 						default: 
 						{
-							LOGINFO("Incorrect Audio Deivce SAD state %d\n", currentSADState); // should not hit this case
+							LOGINFO("Incorrect Audio Device SAD state %d\n", currentSADState); // should not hit this case
 						}
 						break;
 					    }
@@ -5037,9 +5037,9 @@ void DisplaySettings::sendMsgThread()
 		LOGINFO("SAD already cleared\n");
 	    }
 
-        int currentrcRoutingState = getCurrentArcRoutingState();
-	    LOGINFO("Current ARC routing state before update m_currentArcRoutingState=%d\n ", currentrcRoutingState);
-	    if (currentrcRoutingState != ARC_STATE_ARC_TERMINATED) {
+        int currentArcRoutingState = getCurrentArcRoutingState();
+	    LOGINFO("Current ARC routing state before update m_currentArcRoutingState=%d\n ", currentArcRoutingState);
+	    if (currentArcRoutingState != ARC_STATE_ARC_TERMINATED) {
                 if (parameters.HasLabel("status")) {
                     value = parameters["status"].String();
                     std::lock_guard<std::mutex> lock(m_AudioDeviceStatesUpdateMutex);

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -267,7 +267,7 @@ namespace WPEFramework {
 	    bool getHdmiCecSinkAudioDeviceConnectedStatus();
         int getAudioDeviceSADState(void);
         void setAudioDeviceSADState(int newState);
-        int DisplaySettings::getCurrentArcRoutingState(void);
+        int getCurrentArcRoutingState(void);
 
 	    void onTimer();
 	    void stopCecTimeAndUnsubscribeEvent();

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -265,6 +265,9 @@ namespace WPEFramework {
 	    bool sendHdmiCecSinkAudioDevicePowerOn();
 	    bool getHdmiCecSinkCecEnableStatus();
 	    bool getHdmiCecSinkAudioDeviceConnectedStatus();
+        int getAudioDeviceSADState(void);
+        void setAudioDeviceSADState(int newState);
+        int DisplaySettings::getCurrentArcRoutingState(void);
 
 	    void onTimer();
 	    void stopCecTimeAndUnsubscribeEvent();

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -1129,7 +1129,26 @@ namespace WPEFramework {
 
             // there is no /tmp/.make from /lib/rdk/getDeviceDetails.sh, but it can be taken from /etc/device.properties
             if (queryParams.empty() || queryParams == "make") {
+                std::string device_name{};
+                GetValueFromPropertiesFile(DEVICE_PROPERTIES_FILE, "DEVICE_NAME", device_name);
+				if (device_name == "PLATCO") {
+                    IARM_Bus_MFRLib_GetSerializedData_Param_t param;
+					memset(&param, 0, sizeof(param));
+                    param.type = mfrSERIALIZED_TYPE_MANUFACTURER;
 
+                    IARM_Result_t result = IARM_Bus_Call(IARM_BUS_MFRLIB_NAME, IARM_BUS_MFRLIB_API_GetSerializedData, &param, sizeof(param));
+                    param.buffer[param.bufLen] = '\0';
+                    LOGINFO("SystemService getDeviceInfo param type %d result %s bufLen = %d", param.type, param.buffer, param.bufLen);
+
+                    if (result == IARM_RESULT_SUCCESS) {
+                        response["make"] = string(param.buffer);
+                        retAPIStatus = true;
+				       } else {
+                        LOGERR("IARM_BUS_MFRLIB_API_GetSerializedData call was failed");
+						populateResponseWithError(SysSrv_MissingKeyValues, response); // Set an error in the response
+                        retAPIStatus = false;
+					}
+				} else {
                 std::string make;
                 GetValueFromPropertiesFile(DEVICE_PROPERTIES_FILE, "MFG_NAME", make);
 
@@ -1139,7 +1158,7 @@ namespace WPEFramework {
                 } else {
                     populateResponseWithError(SysSrv_MissingKeyValues, response);
                 }
-
+				}
                 if (!queryParams.empty()) {
 
 

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -1147,12 +1147,12 @@ namespace WPEFramework {
                             retAPIStatus = true;
                         } else {
                             LOGERR("IARM_BUS_MFRLIB_API_GetSerializedData returned invalid bufLen %d (capacity %zu)", param.bufLen, sizeof(param.buffer));
-                            populateResponseWithError(SysSrv_MissingKeyValues, response); // Set an error in the response
+                            populateResponseWithError(SysSrv_ManufacturerDataReadFailed, response); // Internal manufacturer data error
                             retAPIStatus = false;
                         }
 				       } else {
                         LOGERR("IARM_BUS_MFRLIB_API_GetSerializedData call failed");
-						populateResponseWithError(SysSrv_MissingKeyValues, response); // Set an error in the response
+						populateResponseWithError(SysSrv_MissingKeyValues, response); // MFR call failed, So return Key Missing error
                         retAPIStatus = false;
 					}
 				} else {

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -1140,7 +1140,7 @@ namespace WPEFramework {
                     LOGINFO("SystemService getDeviceInfo param type %d result %d bufLen = %d", param.type, result, param.bufLen);
 
                     if (result == IARM_RESULT_SUCCESS) {
-                        if (param.bufLen <= static_cast<int>(sizeof(param.buffer))) {
+                        if ((0 < param.bufLen) && (param.bufLen <= static_cast<int>(sizeof(param.buffer)))) {
                             std::string manufacturer(param.buffer, param.bufLen);
                             LOGINFO("SystemService getDeviceInfo manufacturer: %s", manufacturer.c_str());
                             response["make"] = manufacturer;

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -1137,12 +1137,19 @@ namespace WPEFramework {
                     param.type = mfrSERIALIZED_TYPE_MANUFACTURER;
 
                     IARM_Result_t result = IARM_Bus_Call(IARM_BUS_MFRLIB_NAME, IARM_BUS_MFRLIB_API_GetSerializedData, &param, sizeof(param));
-                    param.buffer[param.bufLen] = '\0';
-                    LOGINFO("SystemService getDeviceInfo param type %d result %s bufLen = %d", param.type, param.buffer, param.bufLen);
+                    LOGINFO("SystemService getDeviceInfo param type %d result %d bufLen = %d", param.type, result, param.bufLen);
 
                     if (result == IARM_RESULT_SUCCESS) {
-                        response["make"] = string(param.buffer);
-                        retAPIStatus = true;
+                        if (param.bufLen <= static_cast<int>(sizeof(param.buffer))) {
+                            std::string manufacturer(param.buffer, param.bufLen);
+                            LOGINFO("SystemService getDeviceInfo manufacturer: %s", manufacturer.c_str());
+                            response["make"] = manufacturer;
+                            retAPIStatus = true;
+                        } else {
+                            LOGERR("IARM_BUS_MFRLIB_API_GetSerializedData returned invalid bufLen %d (capacity %zu)", param.bufLen, sizeof(param.buffer));
+                            populateResponseWithError(SysSrv_MissingKeyValues, response); // Set an error in the response
+                            retAPIStatus = false;
+                        }
 				       } else {
                         LOGERR("IARM_BUS_MFRLIB_API_GetSerializedData call failed");
 						populateResponseWithError(SysSrv_MissingKeyValues, response); // Set an error in the response

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -1144,7 +1144,7 @@ namespace WPEFramework {
                         response["make"] = string(param.buffer);
                         retAPIStatus = true;
 				       } else {
-                        LOGERR("IARM_BUS_MFRLIB_API_GetSerializedData call was failed");
+                        LOGERR("IARM_BUS_MFRLIB_API_GetSerializedData call failed");
 						populateResponseWithError(SysSrv_MissingKeyValues, response); // Set an error in the response
                         retAPIStatus = false;
 					}


### PR DESCRIPTION
Reason for change: Cherry-picking of [RDK-E - getDeviceInfo is returning make as Xumo](https://github.com/rdkcentral/entservices-deviceanddisplay/commit/32e646a44175a3e3a64faf55c61976314c9ca1b1) and [RDKEMW-6515: Scan and Fix coverity issues of Entservices and rdkservi…](https://github.com/rdkcentral/entservices-deviceanddisplay/commit/6ee1e038f89633cbf9d51b6071b4dc07661dca01)

Signed-off-by: yuvaramachandran_gurusamy <yuvaramachandran_gurusamy@comcast.com>