### PR TITLE
RDKEMW-16060 : [8.4.4.0][WTA] RDK API getDeviceInfo Returns Bluetooth MAC with Trailing Escape Sequence

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -294,6 +294,21 @@ string collectDeviceInfo(string methodType)
     return respBuffer;
 }
 
+static string sanitizeDeviceDetailsOutput(const string& value)
+{
+    // Strip common ANSI sequences (CSI, OSC, and single-char ESC forms).
+    static const std::regex kAnsiEscapePattern(
+        "\\x1B(?:[@-Z\\\\-_]|\\[[0-?]*[ -/]*[@-~]|\\][^\\x1B\\x07]*(?:\\x07|\\x1B\\\\))");
+    string sanitized = std::regex_replace(value, kAnsiEscapePattern, "");
+
+    sanitized.erase(std::remove_if(sanitized.begin(), sanitized.end(), [](unsigned char ch) {
+        return std::iscntrl(ch);
+    }), sanitized.end());
+
+    Utils::String::trim(sanitized);
+    return sanitized;
+}
+
 #if defined(USE_IARMBUS) || defined(USE_IARM_BUS)
 
 std::string iarmModeToString(IARM_Bus_Daemon_SysMode_t& iarmMode)
@@ -1313,7 +1328,7 @@ namespace WPEFramework {
                         if (std::string::npos != eq)
                         {
                             std::string key = line.substr(0, eq);
-                            std::string value = line.substr(eq + 1);
+                            std::string value = sanitizeDeviceDetailsOutput(line.substr(eq + 1));
 
                             response[key.c_str()] = value;
 
@@ -1339,8 +1354,8 @@ namespace WPEFramework {
 #endif
                 } else {
                     retAPIStatus = true;
-                    Utils::String::trim(res);
-                        response[queryParams.c_str()] = res;
+                    std::string sanitizedValue = sanitizeDeviceDetailsOutput(res);
+                    response[queryParams.c_str()] = sanitizedValue;
                     }
                 }
             returnResponse(retAPIStatus);
@@ -2901,9 +2916,9 @@ namespace WPEFramework {
 
                }
 
-                removeCharsFromString(tempBuffer, "\n\r");
-                LOGWARN("resp = %s\n", tempBuffer.c_str());
-                params[macTypeList[i].c_str()] = (tempBuffer.empty()? "00:00:00:00:00:00" : tempBuffer.c_str());
+                tempBuffer = sanitizeDeviceDetailsOutput(tempBuffer);
+                const char* macValue = (tempBuffer.empty()? "00:00:00:00:00:00" : tempBuffer.c_str());
+                params[macTypeList[i].c_str()] = macValue;
                 listLength++;
             }
             if (listLength != i) {

--- a/Tests/L1Tests/tests/test_SystemServices.cpp
+++ b/Tests/L1Tests/tests/test_SystemServices.cpp
@@ -3942,7 +3942,7 @@ TEST_F(SystemServicesEventTest, onMacAddressesRetrieved)
                     valueToReturn = "A8:11:XX:FD:0C:XX";
                 } else if (strcmp(strFmt, "/lib/rdk/getDeviceDetails.sh read bluetooth_mac") == 0) {
                     EXPECT_EQ(string(strFmt), string(_T("/lib/rdk/getDeviceDetails.sh read bluetooth_mac")));
-                    valueToReturn = "AA:AA:AA:AA:AA:AA";
+                    valueToReturn = "AA:AA:AA:AA:AA:AA\x1B[0m";
                 } else if (strcmp(strFmt, "/lib/rdk/getDeviceDetails.sh read rf4ce_mac") == 0) {
                     EXPECT_EQ(string(strFmt), string(_T("/lib/rdk/getDeviceDetails.sh read rf4ce_mac")));
                     valueToReturn = "00:00:00:00:00:00";


### PR DESCRIPTION
Reason for change: bluetooth_mac appends esc sequence in the end. 
Test Procedure: check the bluetooth_mac via"org.rdk.System.getDeviceInfo". there should be no esc sequence in the end of bluetooth_mac
Risks: Low
version : minor
Priority: P1
 
Signed-off-by:Naveen_Dunna [Naveen_Dunna@comcast.com](mailto:Naveen_Dunna@comcast.com)